### PR TITLE
switched the homepage to be a String

### DIFF
--- a/src/main/java/com/spotify/github/v3/repos/RepositoryBase.java
+++ b/src/main/java/com/spotify/github/v3/repos/RepositoryBase.java
@@ -154,7 +154,7 @@ public interface RepositoryBase extends UpdateTracking {
   URI hooksUrl();
 
   /** Homepage URL */
-  Optional<URI> homepage();
+  Optional<String> homepage();
 
   /** Language */
   Optional<String> language();


### PR DESCRIPTION
 URIs are not enforced by github for this field, so it breaks the deserializer if it's not valid.