### PR TITLE
update to latest com.spotify:foss-root

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -455,14 +455,6 @@
 
             <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.1</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>8.29</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
                     <configLocation>${checkstyle.config.location}</configLocation>
                     <consoleOutput>true</consoleOutput>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.spotify</groupId>
         <artifactId>foss-root</artifactId>
-        <version>10</version>
+        <version>14</version>
     </parent>
 
     <licenses>


### PR DESCRIPTION
in particular this fixes the license plugin causing formatting
conflicts with maven-fmt-plugin (or the IntelliJ plugin for Google's
code style)
