### PR TITLE
fix tests that fail for the wrong reasons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <guava.version>28.0-jre</guava.version>
         <jsr305.version>3.0.2</jsr305.version>
         <jsr311-api.version>1.1.1</jsr311-api.version>
-        <junit.version>4.13</junit.version>
+        <junit.version>4.13.1</junit.version>
         <slf4j-api.version>1.7.12</slf4j-api.version>
         <mockito-core.version>3.2.4</mockito-core.version>
         <commons-io.version>2.6</commons-io.version>


### PR DESCRIPTION
I noticed that the test `assertJwtEndpointWithNoKeyThrows()` was taking
10 seconds to run so I took a look into why that was.

The test method has `@Test(expected=Exception.class)` but the exception
that is thrown is different than the one that the test is expected - the
test was throwing a SocketTimeoutException after 10 seconds (which is
the OkHttpClient's default read timeout setting) because there was no
mock requests enqueued in the mock web server.

I refactored these tests to use `assertThrows` instead to assert against
the details of the thrown Exceptions, and also fixed what seems like a
bug in the `getAuthorizationHeader` method - if the client has an
accessToken, it will be used as the header, even if the request path is
one that needs a private-key-signed JWT token.
