### PR TITLE
Pass in access token in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ issueClient.listComments(ISSUE_ID).get().forEach(comment -> log.info(comment.bod
 ### Simple access token
 
 ```java
-final GitHubClient github = GitHubClient.create(URI.create("https://github.com/api/v3/"));
+final GitHubClient github = GitHubClient.create(URI.create("https://github.com/api/v3/"), "my-access-token");
 // Do the requests
 github.createRepositoryClient("my-org", "my-repo").getCommit("sha");
 ```
@@ -75,7 +75,7 @@ This library attempts to mirror the structure of GitHub API endpoints. As an exa
 the `GET /repos/:owner/:repo/commits` API call, under the `repos` API. Therefore, the `getCommit` method lives in the RepositoryClient.
 
 ```java
-final GitHubClient github = GitHubClient.create(URI.create("https://github.com/api/v3/"));
+final GitHubClient github = GitHubClient.create(URI.create("https://github.com/api/v3/"), "my-access-token");
 github.createRepositoryClient("my-org", "my-repo").getCommit("sha");
 ```
 


### PR DESCRIPTION
The example code snippet misses the access token.