### PR TITLE
Close response to avoid leaking

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/GithubPage.java
+++ b/src/main/java/com/spotify/github/v3/clients/GithubPage.java
@@ -38,6 +38,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
+import okhttp3.ResponseBody;
 
 /**
  * Async page implementation for github resources
@@ -158,16 +159,13 @@ public class GithubPage<T> implements AsyncPage<T> {
         .request(path)
         .thenApply(
             response -> {
-                final Map<String, Link> linkMap = Optional.ofNullable(response.headers().get("Link"))
+                Optional.ofNullable(response.body()).ifPresent(ResponseBody::close);
+                return Optional.ofNullable(response.headers().get("Link"))
                     .map(linkHeader -> stream(linkHeader.split(",")))
                     .orElseGet(Stream::empty)
                     .map(linkString -> Link.from(linkString.split(";")))
                     .filter(link -> link.rel().isPresent())
                     .collect(toMap(link -> link.rel().get(), identity()));
-                if (response.body() != null) {
-                  response.close();
-                }
-                return linkMap;
             });
   }
 

--- a/src/main/java/com/spotify/github/v3/clients/GithubPage.java
+++ b/src/main/java/com/spotify/github/v3/clients/GithubPage.java
@@ -157,13 +157,18 @@ public class GithubPage<T> implements AsyncPage<T> {
     return github
         .request(path)
         .thenApply(
-            response ->
-                Optional.ofNullable(response.headers().get("Link"))
+            response -> {
+                final Map<String, Link> linkMap = Optional.ofNullable(response.headers().get("Link"))
                     .map(linkHeader -> stream(linkHeader.split(",")))
                     .orElseGet(Stream::empty)
                     .map(linkString -> Link.from(linkString.split(";")))
                     .filter(link -> link.rel().isPresent())
-                    .collect(toMap(link -> link.rel().get(), identity())));
+                    .collect(toMap(link -> link.rel().get(), identity()));
+                if (response.body() != null) {
+                  response.close();
+                }
+                return linkMap;
+            });
   }
 
   private Optional<Integer> pageNumberFromUri(final String uri) {


### PR DESCRIPTION
In case there is a body, it should either be read through or closed.