### PR TITLE
GitHub Client - Provide privateKey as byte array

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/GitHubClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/GitHubClient.java
@@ -38,9 +38,8 @@ import com.spotify.github.v3.repos.CommitItem;
 import com.spotify.github.v3.repos.FolderContent;
 import com.spotify.github.v3.repos.Repository;
 import com.spotify.github.v3.repos.Status;
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
+
+import java.io.*;
 import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.time.ZonedDateTime;
@@ -56,6 +55,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
 import okhttp3.*;
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,7 +99,7 @@ public class GitHubClient {
   private final OkHttpClient client;
   private final String token;
 
-  private final File privateKey;
+  private final byte[] privateKey;
   private final Integer appId;
   private final Integer installationId;
 
@@ -109,7 +109,7 @@ public class GitHubClient {
       final OkHttpClient client,
       final URI baseUrl,
       final String accessToken,
-      final File privateKey,
+      final byte[] privateKey,
       final Integer appId,
       final Integer installationId) {
     this.baseUrl = baseUrl;
@@ -141,6 +141,18 @@ public class GitHubClient {
    * @return github api client
    */
   public static GitHubClient create(final URI baseUrl, final File privateKey, final Integer appId) {
+    return createOrThrow(new OkHttpClient(), baseUrl, privateKey, appId, null);
+  }
+
+  /**
+   * Create a github api client with a given base URL and a path to a key.
+   *
+   * @param baseUrl base URL
+   * @param privateKey the private key as byte array
+   * @param appId the github app ID
+   * @return github api client
+   */
+  public static GitHubClient create(final URI baseUrl, final byte[] privateKey, final Integer appId) {
     return new GitHubClient(new OkHttpClient(), baseUrl, null, privateKey, appId, null);
   }
 
@@ -155,6 +167,20 @@ public class GitHubClient {
    */
   public static GitHubClient create(
       final URI baseUrl, final File privateKey, final Integer appId, final Integer installationId) {
+    return createOrThrow(new OkHttpClient(), baseUrl, privateKey, appId, installationId);
+  }
+
+  /**
+   * Create a github api client with a given base URL and a path to a key.
+   *
+   * @param baseUrl base URL
+   * @param privateKey the private key as byte array
+   * @param appId the github app ID
+   * @param installationId the installationID to be authenticated as
+   * @return github api client
+   */
+  public static GitHubClient create(
+          final URI baseUrl, final byte[] privateKey, final Integer appId, final Integer installationId) {
     return new GitHubClient(new OkHttpClient(), baseUrl, null, privateKey, appId, installationId);
   }
 
@@ -172,6 +198,23 @@ public class GitHubClient {
       final URI baseUrl,
       final File privateKey,
       final Integer appId) {
+    return createOrThrow(httpClient, baseUrl, privateKey, appId, null);
+  }
+
+  /**
+   * Create a github api client with a given base URL and a path to a key.
+   *
+   * @param httpClient an instance of OkHttpClient
+   * @param baseUrl base URL
+   * @param privateKey the private key as byte array
+   * @param appId the github app ID
+   * @return github api client
+   */
+  public static GitHubClient create(
+          final OkHttpClient httpClient,
+          final URI baseUrl,
+          final byte[] privateKey,
+          final Integer appId) {
     return new GitHubClient(httpClient, baseUrl, null, privateKey, appId, null);
   }
 
@@ -190,6 +233,24 @@ public class GitHubClient {
       final File privateKey,
       final Integer appId,
       final Integer installationId) {
+    return createOrThrow(httpClient, baseUrl, privateKey, appId, installationId);
+  }
+
+  /**
+   * Create a github api client with a given base URL and a path to a key.
+   *
+   * @param httpClient an instance of OkHttpClient
+   * @param baseUrl base URL
+   * @param privateKey the private key as byte array
+   * @param appId the github app ID
+   * @return github api client
+   */
+  public static GitHubClient create(
+          final OkHttpClient httpClient,
+          final URI baseUrl,
+          final byte[] privateKey,
+          final Integer appId,
+          final Integer installationId) {
     return new GitHubClient(httpClient, baseUrl, null, privateKey, appId, installationId);
   }
 
@@ -215,7 +276,7 @@ public class GitHubClient {
    */
   public static GitHubClient scopeForInstallationId(
       final GitHubClient client, final int installationId) {
-    if (!client.getPrivateKey().isPresent()) {
+    if (client.getPrivateKey().isEmpty()) {
       throw new RuntimeException("Installation ID scoped client needs a private key");
     }
     return new GitHubClient(
@@ -235,7 +296,7 @@ public class GitHubClient {
     }
   }
 
-  public Optional<File> getPrivateKey() {
+  public Optional<byte[]> getPrivateKey() {
     return Optional.ofNullable(privateKey);
   }
 
@@ -546,7 +607,7 @@ public class GitHubClient {
     } else if (getPrivateKey().isPresent()) {
       final String jwtToken;
       try {
-        jwtToken = JwtTokenIssuer.fromFile(privateKey).getToken(appId);
+        jwtToken = JwtTokenIssuer.fromPrivateKey(privateKey).getToken(appId);
       } catch (Exception e) {
         throw new RuntimeException("There was an error generating JWT token", e);
       }
@@ -692,5 +753,16 @@ public class GitHubClient {
     }
 
     return completedFuture(response);
+  }
+
+  /**
+   * Wrapper to Constructors that expose File object for the privateKey argument
+   * */
+  private static GitHubClient createOrThrow(final OkHttpClient httpClient, final URI baseUrl, final File privateKey, final Integer appId, final Integer installationId) {
+    try {
+      return new GitHubClient(httpClient, baseUrl, null, FileUtils.readFileToByteArray(privateKey), appId, installationId);
+    } catch (IOException e) {
+      throw new RuntimeException("There was an error generating JWT token", e);
+    }
   }
 }

--- a/src/main/java/com/spotify/github/v3/clients/JwtTokenIssuer.java
+++ b/src/main/java/com/spotify/github/v3/clients/JwtTokenIssuer.java
@@ -22,8 +22,7 @@ package com.spotify.github.v3.clients;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import java.io.File;
-import java.io.IOException;
+
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
@@ -31,7 +30,6 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Date;
-import org.apache.commons.io.FileUtils;
 
 /** The helper Jwt token issuer. */
 public class JwtTokenIssuer {
@@ -43,20 +41,6 @@ public class JwtTokenIssuer {
 
   private JwtTokenIssuer(final PrivateKey signingKey) {
     this.signingKey = signingKey;
-  }
-
-  /**
-   * Instantiates a new Jwt token issuer.
-   *
-   * @param privateKeyFile the private key file
-   * @throws NoSuchAlgorithmException the no such algorithm exception
-   * @throws InvalidKeySpecException the invalid key spec exception
-   * @throws IOException the io exception
-   */
-  public static JwtTokenIssuer fromFile(final File privateKeyFile)
-      throws NoSuchAlgorithmException, InvalidKeySpecException, IOException {
-    byte[] apiKeySecretBytes = FileUtils.readFileToByteArray(privateKeyFile);
-    return fromPrivateKey(apiKeySecretBytes);
   }
 
   /**


### PR DESCRIPTION
This is to enable the option to create the `GitHubClient` with privateKey as a `byte[]` rather than the limited option of `File` object.
use case example: privateKey file is packed in the jar file of the consuming application. creating a `File` object in that case is tedious, and would have been preferred to simply load the resources, stream it and get the bytes.

`GitHubClient` create methods expecting `File` **remain** for backwards compatibility

Would be happy to have that pushed in, or get comments about the implementation and use case