### PR TITLE
Close all ignored response bodies

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/GitHubClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/GitHubClient.java
@@ -65,7 +65,11 @@ import org.slf4j.LoggerFactory;
  */
 public class GitHubClient {
 
-  static final Consumer<Response> IGNORE_RESPONSE_CONSUMER = (ignore) -> {};
+  static final Consumer<Response> IGNORE_RESPONSE_CONSUMER = (response) -> {
+    if (response.body() != null) {
+      response.body().close();
+    }
+  };
   static final TypeReference<List<Comment>> LIST_COMMENT_TYPE_REFERENCE =
       new TypeReference<>() {};
   static final TypeReference<List<Repository>> LIST_REPOSITORY =


### PR DESCRIPTION
This fixes several warnings of this form (#65):
A connection to https://github.com/ was leaked. Did you forget to close a response body?

According to the okhttp documentation:
"Response bodies must be closed and may be consumed only once"
https://square.github.io/okhttp/4.x/okhttp/okhttp3/-response/body/