### PR TITLE
Add path and status code to exception message

### DIFF
--- a/src/main/java/com/spotify/github/v3/exceptions/RequestNotOkException.java
+++ b/src/main/java/com/spotify/github/v3/exceptions/RequestNotOkException.java
@@ -40,6 +40,10 @@ public class RequestNotOkException extends GithubException {
   private final int statusCode;
   private final String path;
 
+  private static String decoratedMessage(final String path, final int statusCode, final String msg) {
+    return String.format("%s %d: %s", path, statusCode, msg);
+  }
+
   /**
    * Response to request came back with non-2xx status code
    *
@@ -48,7 +52,7 @@ public class RequestNotOkException extends GithubException {
    * @param msg response body
    */
   public RequestNotOkException(final String path, final int statusCode, final String msg) {
-    super(msg);
+    super(decoratedMessage(path, statusCode, msg));
     this.statusCode = statusCode;
     this.path = path;
   }
@@ -63,7 +67,7 @@ public class RequestNotOkException extends GithubException {
    */
   public RequestNotOkException(
       final String path, final int statusCode, final String msg, final Throwable cause) {
-    super(msg, cause);
+    super(decoratedMessage(path, statusCode, msg), cause);
     this.statusCode = statusCode;
     this.path = path;
   }


### PR DESCRIPTION
Before this change, if you got a `RequestNotOkException` in a log file, it wasn't possible to see which request it was that failed.

With this change in place, the path and status code of the exception are prepended to the exception message, and any logged exceptions will contain information on what operation it was that failed.
