### PR TITLE
Parse and fix broken github api urls

### DIFF
--- a/src/main/java/com/spotify/github/v3/repos/Branch.java
+++ b/src/main/java/com/spotify/github/v3/repos/Branch.java
@@ -21,11 +21,20 @@
 package com.spotify.github.v3.repos;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.spotify.github.GithubStyle;
+import com.spotify.github.v3.git.ImmutableShaLink;
 import com.spotify.github.v3.git.ShaLink;
+import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
@@ -34,7 +43,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @GithubStyle
 @JsonSerialize(as = ImmutableBranch.class)
-@JsonDeserialize(as = ImmutableBranch.class)
+@JsonDeserialize(as = ImmutableBranch.class, using = BranchDeserializer.class)
 public interface Branch {
 
   /** Branch name */
@@ -51,4 +60,47 @@ public interface Branch {
 
   /** Branch protection API URL */
   Optional<URI> protectionUrl();
+}
+
+class BranchDeserializer extends JsonDeserializer<ImmutableBranch> {
+
+  private URI fixInvalidGithubUrl(final String invalidUrl) throws IOException {
+    // There's a bug in github where it gives you back non-url-encoded characters
+    // in the protection_url field. For example if your branch has a single "%" in its name.
+    // As of this writing, the protection URL looks something like this
+    // https://github-server.tld/api/v3/repos/owner/repo-name/branches/branch-name/protection
+    final String[] schemaAndPath = invalidUrl.split("//");
+    String[] pathParts = schemaAndPath[1].split("/");
+    for (int i = 0; i < pathParts.length; i++) {
+      pathParts[i] = URLEncoder.encode(pathParts[i], StandardCharsets.UTF_8);
+    }
+    String fixedUrlString = schemaAndPath[0] + "//" + String.join("/", pathParts);
+    return URI.create(fixedUrlString);
+  }
+
+  @Override
+  public ImmutableBranch deserialize(final JsonParser jsonParser, final DeserializationContext deserializationContext)
+      throws IOException {
+    JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+    URI protectionUrl;
+    var immutableBranchBuilder = ImmutableBranch.builder();
+    if (node.has("protected")) {
+      immutableBranchBuilder.isProtected(node.get("protected").asBoolean());
+      String protectionUrlString = node.get("protection_url").asText();
+      try {
+        protectionUrl = new URI(protectionUrlString);
+      } catch (URISyntaxException e) {
+        protectionUrl = fixInvalidGithubUrl(protectionUrlString);
+      }
+      immutableBranchBuilder.protectionUrl(protectionUrl);
+    }
+    ImmutableShaLink shaLink = ImmutableShaLink.builder()
+        .sha(node.get("commit").get("sha").asText())
+        .url(URI.create(node.at("/commit/url").asText()))
+        .build();
+    return immutableBranchBuilder
+        .name(node.get("name").textValue())
+        .commit(shaLink)
+        .build();
+  }
 }

--- a/src/main/java/com/spotify/github/v3/repos/BranchDeserializer.java
+++ b/src/main/java/com/spotify/github/v3/repos/BranchDeserializer.java
@@ -1,0 +1,76 @@
+/*-
+ * -\-\-
+ * github-api
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.github.v3.repos;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.spotify.github.v3.git.ImmutableShaLink;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+public class BranchDeserializer extends JsonDeserializer<ImmutableBranch> {
+
+  private URI fixInvalidGithubUrl(final String invalidUrl) throws IOException {
+    // There's a bug in github where it gives you back non-url-encoded characters
+    // in the protection_url field. For example if your branch has a single "%" in its name.
+    // As of this writing, the protection URL looks something like this
+    // https://github-server.tld/api/v3/repos/owner/repo-name/branches/branch-name/protection
+    final String[] schemaAndPath = invalidUrl.split("//");
+    String[] pathParts = schemaAndPath[1].split("/");
+    for (int i = 0; i < pathParts.length; i++) {
+      pathParts[i] = URLEncoder.encode(pathParts[i], StandardCharsets.UTF_8);
+    }
+    String fixedUrlString = schemaAndPath[0] + "//" + String.join("/", pathParts);
+    return URI.create(fixedUrlString);
+  }
+
+  @Override
+  public ImmutableBranch deserialize(final JsonParser jsonParser,
+      final DeserializationContext deserializationContext)
+      throws IOException {
+    JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+    URI protectionUrl;
+    var immutableBranchBuilder = ImmutableBranch.builder();
+    if (node.has("protected")) {
+      immutableBranchBuilder.isProtected(node.get("protected").asBoolean());
+      String protectionUrlString = node.get("protection_url").asText();
+      try {
+        protectionUrl = new URI(protectionUrlString);
+      } catch (URISyntaxException e) {
+        protectionUrl = fixInvalidGithubUrl(protectionUrlString);
+      }
+      immutableBranchBuilder.protectionUrl(protectionUrl);
+    }
+    ImmutableShaLink shaLink = ImmutableShaLink.builder()
+        .sha(node.get("commit").get("sha").asText())
+        .url(URI.create(node.at("/commit/url").asText()))
+        .build();
+    return immutableBranchBuilder
+        .name(node.get("name").textValue())
+        .commit(shaLink)
+        .build();
+  }
+}

--- a/src/test/resources/com/spotify/github/v3/repos/branch-escape-chars-url-variation-two.json
+++ b/src/test/resources/com/spotify/github/v3/repos/branch-escape-chars-url-variation-two.json
@@ -1,0 +1,9 @@
+{
+  "name": "unescaped-percent-sign-%",
+  "commit": {
+    "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+    "url": "https://api.github.com/repos/octocat/Hello-World/commits/c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc"
+  },
+  "protected": true,
+  "protection_url": "https://api.github.com/api/v3/repos/octocat/Hello-World/branches/branch-name-with-slashes/unescaped-percent-sign-%/protection"
+}

--- a/src/test/resources/com/spotify/github/v3/repos/branch-escape-chars.json
+++ b/src/test/resources/com/spotify/github/v3/repos/branch-escape-chars.json
@@ -1,0 +1,9 @@
+{
+  "name": "unescaped-percent-sign-%",
+  "commit": {
+    "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+    "url": "https://api.github.com/repos/octocat/Hello-World/commits/c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc"
+  },
+  "protected": true,
+  "protection_url": "https://api.github.com/repos/octocat/Hello-World/branches/unescaped-percent-sign-%/protection"
+}

--- a/src/test/resources/com/spotify/github/v3/repos/branch-not-protected.json
+++ b/src/test/resources/com/spotify/github/v3/repos/branch-not-protected.json
@@ -1,0 +1,7 @@
+{
+  "name": "master",
+  "commit": {
+    "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+    "url": "https://api.github.com/repos/octocat/Hello-World/commits/c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc"
+  }
+}


### PR DESCRIPTION
If a branch has a percent symbol in it, github will sometimes return a
URI that java's URI object can't parse. This patch ensures that in such
a case we url-escape the branch name.