### PR TITLE
Expose github error message in RequestNotOkException.

### DIFF
--- a/src/main/java/com/spotify/github/opencensus/OpenCensusSpan.java
+++ b/src/main/java/com/spotify/github/opencensus/OpenCensusSpan.java
@@ -46,7 +46,7 @@ class OpenCensusSpan implements Span {
         if (t instanceof RequestNotOkException) {
             RequestNotOkException ex = (RequestNotOkException) t;
             span.putAttribute("http.status_code", AttributeValue.longAttributeValue(ex.statusCode()));
-            span.putAttribute("message", AttributeValue.stringAttributeValue(ex.getMessage()));
+            span.putAttribute("message", AttributeValue.stringAttributeValue(ex.getRawMessage()));
             if (ex.statusCode() - INTERNAL_SERVER_ERROR >= 0) {
                 span.putAttribute("error", AttributeValue.booleanAttributeValue(true));
             }

--- a/src/main/java/com/spotify/github/v3/exceptions/RequestNotOkException.java
+++ b/src/main/java/com/spotify/github/v3/exceptions/RequestNotOkException.java
@@ -39,6 +39,7 @@ public class RequestNotOkException extends GithubException {
 
   private final int statusCode;
   private final String path;
+  private final String msg;
 
   private static String decoratedMessage(final String path, final int statusCode, final String msg) {
     return String.format("%s %d: %s", path, statusCode, msg);
@@ -55,6 +56,7 @@ public class RequestNotOkException extends GithubException {
     super(decoratedMessage(path, statusCode, msg));
     this.statusCode = statusCode;
     this.path = path;
+    this.msg = msg;
   }
 
   /**
@@ -70,6 +72,16 @@ public class RequestNotOkException extends GithubException {
     super(decoratedMessage(path, statusCode, msg), cause);
     this.statusCode = statusCode;
     this.path = path;
+    this.msg = msg;
+  }
+
+  /**
+   * Get the raw message from github
+   *
+   * @return msg
+   */
+  public String getRawMessage() {
+    return msg;
   }
 
   /**

--- a/src/test/java/com/spotify/github/v3/clients/GitHubClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/GitHubClientTest.java
@@ -131,6 +131,7 @@ public class GitHubClientTest {
       RequestNotOkException e1 = (RequestNotOkException) e.getCause();
       assertThat(e1.statusCode(), is(409));
       assertThat(e1.getMessage(), containsString("Merge Conflict"));
+      assertThat(e1.getRawMessage(), containsString("Merge Conflict"));
     }
   }
 }


### PR DESCRIPTION
Exposing the original response payload from github makes it easier for a client to determine the cause of problem.
