### PR TITLE
Add isArchived method handling archived property of Repository

### DIFF
--- a/src/main/java/com/spotify/github/v3/repos/RepositoryBase.java
+++ b/src/main/java/com/spotify/github/v3/repos/RepositoryBase.java
@@ -58,6 +58,11 @@ public interface RepositoryBase extends UpdateTracking {
   @JsonProperty("private")
   Boolean isPrivate();
 
+  /** Is it archived */
+  @Nullable
+  @JsonProperty("archived")
+  Boolean isArchived();
+
   /** Is it public */
   @JsonProperty("public")
   Optional<Boolean> isPublic();

--- a/src/test/java/com/spotify/github/v3/clients/RepositoryClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/RepositoryClientTest.java
@@ -106,6 +106,7 @@ public class RepositoryClientTest {
     assertThat(repository.name(), is("Hello-World"));
     assertThat(repository.fullName(), is(repository.owner().login() + "/Hello-World"));
     assertThat(repository.isPrivate(), is(false));
+    assertThat(repository.isArchived(), is(false));
     assertThat(repository.fork(), is(false));
   }
 

--- a/src/test/java/com/spotify/github/v3/repos/RepositoryTest.java
+++ b/src/test/java/com/spotify/github/v3/repos/RepositoryTest.java
@@ -49,5 +49,6 @@ public class RepositoryTest {
     assertThat(repository.name(), is("Hello-World"));
     assertThat(repository.fullName(), is(repository.owner().login() + "/Hello-World"));
     assertThat(repository.isPrivate(), is(false));
+    assertThat(repository.isArchived(), is(false));
   }
 }

--- a/src/test/resources/com/spotify/github/v3/repos/repository.json
+++ b/src/test/resources/com/spotify/github/v3/repos/repository.json
@@ -23,6 +23,7 @@
   "full_name": "octocat/Hello-World",
   "description": "This your first repo!",
   "private": false,
+  "archived": false,
   "fork": true,
   "url": "https://api.github.com/repos/octocat/Hello-World",
   "html_url": "https://github.com/octocat/Hello-World",

--- a/src/test/resources/com/spotify/github/v3/repos/repository_get.json
+++ b/src/test/resources/com/spotify/github/v3/repos/repository_get.json
@@ -23,6 +23,7 @@
   "full_name": "octocat/Hello-World",
   "description": "This your first repo!",
   "private": false,
+  "archived": false,
   "fork": false,
   "url": "https://api.github.com/repos/octocat/Hello-World",
   "html_url": "https://github.com/octocat/Hello-World",


### PR DESCRIPTION
The archived property included and exposed via isArchived method.
This helps avoiding to make any github calls which would result in error when the repository is archived.
So before making such calls (create comment/status etc.) - the isArchived method could be checked to avoid making other calls.