### PR TITLE
Fix parsing non-protected branches + simplify deserialization

### DIFF
--- a/src/main/java/com/spotify/github/v3/repos/Branch.java
+++ b/src/main/java/com/spotify/github/v3/repos/Branch.java
@@ -34,7 +34,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @GithubStyle
 @JsonSerialize(as = ImmutableBranch.class)
-@JsonDeserialize(as = ImmutableBranch.class, using = BranchDeserializer.class)
+@JsonDeserialize(as = ImmutableBranch.class)
 public interface Branch {
 
   /** Branch name */
@@ -50,6 +50,7 @@ public interface Branch {
   Optional<Boolean> isProtected();
 
   /** Branch protection API URL */
+  @JsonDeserialize(using = BranchProtectionUrlDeserializer.class)
   Optional<URI> protectionUrl();
 }
 

--- a/src/test/java/com/spotify/github/v3/clients/RepositoryClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/RepositoryClientTest.java
@@ -251,6 +251,7 @@ public class RepositoryClientTest {
         .thenReturn(fixture);
     final Branch branch = repoClient.getBranch("somebranch").get();
     assertThat(branch.isProtected().orElse(false), is(true));
+    assertThat(branch.protectionUrl().get().toString(), is("https://api.github.com/repos/octocat/Hello-World/branches/master/protection"));
     assertThat(branch.commit().sha(), is("6dcb09b5b57875f334f61aebed695e2e4193db5e"));
     assertThat(
         branch.commit().url().toString(),
@@ -258,14 +259,26 @@ public class RepositoryClientTest {
   }
 
   @Test
-  public void getBranchWithoutProtection() throws Exception {
-    // Make sure the custom deserialiser correctly handles the optional protected fields
+  public void getBranchWithNoProtection() throws Exception {
     final CompletableFuture<Branch> fixture =
         completedFuture(json.fromJson(getFixture("branch-not-protected.json"), Branch.class));
     when(github.request("/repos/someowner/somerepo/branches/somebranch", Branch.class))
         .thenReturn(fixture);
     final Branch branch = repoClient.getBranch("somebranch").get();
     assertThat(branch.isProtected().orElse(false), is(false));
+    assertTrue(branch.protectionUrl().isEmpty());
+    assertThat(branch.commit().sha(), is("6dcb09b5b57875f334f61aebed695e2e4193db5e"));
+  }
+
+  @Test
+  public void getBranchWithoutProtectionFields() throws Exception {
+    final CompletableFuture<Branch> fixture =
+        completedFuture(json.fromJson(getFixture("branch-no-protection-fields.json"), Branch.class));
+    when(github.request("/repos/someowner/somerepo/branches/somebranch", Branch.class))
+        .thenReturn(fixture);
+    final Branch branch = repoClient.getBranch("somebranch").get();
+    assertThat(branch.isProtected().orElse(false), is(false));
+    assertTrue(branch.protectionUrl().isEmpty());
     assertThat(branch.commit().sha(), is("6dcb09b5b57875f334f61aebed695e2e4193db5e"));
     assertThat(
         branch.commit().url().toString(),

--- a/src/test/resources/com/spotify/github/v3/repos/branch-no-protection-fields.json
+++ b/src/test/resources/com/spotify/github/v3/repos/branch-no-protection-fields.json
@@ -3,6 +3,5 @@
   "commit": {
     "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
     "url": "https://api.github.com/repos/octocat/Hello-World/commits/c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc"
-  },
-  "protected": false
+  }
 }


### PR DESCRIPTION
In https://github.com/spotify/github-java-client/pull/82 we
added a custom deserializer for the `Branch` class.

This deserializer didn't handle certain cases properly that the GH API
would return. In particular the case where the `protected` field was set
and no `protection_url` is present would lead to a NPE in the
deserializer.

To avoid this error and make the whole parser more resilient to
different API results, let's reduce the scope of the custom deserializer
to only parse the `protection_url` field instead of the whole `Branch`
class.

There should be no change in runtime behavior apart from fixing the
error cases.