### PR TITLE
Fix javadoc generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -371,32 +371,6 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.2.0</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/generated-sources/annotations</sourcepath>
-                            <additionalDependencies>
-                                <additionalDependency>
-                                    <groupId>javax.annotation</groupId>
-                                    <artifactId>javax.annotation-api</artifactId>
-                                    <version>1.3.2</version>
-                                </additionalDependency>
-
-                            </additionalDependencies>
-                            <doclint>none</doclint>
-                        </configuration>
-
-                    </plugin>
-                    <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                         <version>1.6.8</version>
@@ -528,6 +502,22 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <release>11</release>
+                    <doclint>none</doclint>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
- Specify javadoc target release to fix java version mismatch errors
- Remove lots of workarounds that are no longer needed
- Run javadoc in all profiles to catch errors during PR testing, not
  just before publishing a release