### PR TITLE
Upgrade to codecov-action v2

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Build
       run: mvn -B package --file pom.xml -Pcoverage -Dsytle.colors=always --errors
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         nexus_username: ${{ secrets.nexus_username }}
         nexus_password: ${{ secrets.nexus_password }}
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 #    - name: Release


### PR DESCRIPTION
v1 no longer works properly, so let's upgrade
See https://github.com/codecov/codecov-action#%EF%B8%8F--deprecation-of-v1