### PR TITLE
Fix coverage upload on main builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
         gpg_passphrase: ${{ secrets.gpg_passphrase }}
         nexus_username: ${{ secrets.nexus_username }}
         nexus_password: ${{ secrets.nexus_password }}
+        maven_args: '-Pcoverage'
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       with:


### PR DESCRIPTION
We need to enable the `coverage` profile in the main build/publish maven
step, otherwise codecov has nothing to upload.