### PR TITLE
Remove code for nested RequestNotOkException

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
@@ -205,8 +205,7 @@ public class RepositoryClient {
                   return null;
                 }
 
-                throw new RequestNotOkException(
-                    e1.path(), e1.statusCode(), "Failed creating a webhook: " + request, e);
+                throw e1;
               }
 
               throw new CompletionException(e);

--- a/src/main/java/com/spotify/github/v3/exceptions/ReadOnlyRepositoryException.java
+++ b/src/main/java/com/spotify/github/v3/exceptions/ReadOnlyRepositoryException.java
@@ -32,17 +32,4 @@ public class ReadOnlyRepositoryException extends RequestNotOkException {
   public ReadOnlyRepositoryException(final String path, final int statusCode, final String msg) {
     super(path, statusCode, msg);
   }
-
-  /**
-   * Instantiates a new Read only repository exception.
-   *
-   * @param path the path
-   * @param statusCode the status code
-   * @param msg the msg
-   * @param cause the cause
-   */
-  public ReadOnlyRepositoryException(
-      final String path, final int statusCode, final String msg, final Throwable cause) {
-    super(path, statusCode, msg, cause);
-  }
 }

--- a/src/main/java/com/spotify/github/v3/exceptions/RequestNotOkException.java
+++ b/src/main/java/com/spotify/github/v3/exceptions/RequestNotOkException.java
@@ -60,22 +60,6 @@ public class RequestNotOkException extends GithubException {
   }
 
   /**
-   * Response to request came back with non-2xx status code
-   *
-   * @param path URI path
-   * @param statusCode status of repsonse
-   * @param msg response body
-   * @param cause exception cause
-   */
-  public RequestNotOkException(
-      final String path, final int statusCode, final String msg, final Throwable cause) {
-    super(decoratedMessage(path, statusCode, msg), cause);
-    this.statusCode = statusCode;
-    this.path = path;
-    this.msg = msg;
-  }
-
-  /**
    * Get the raw message from github
    *
    * @return msg


### PR DESCRIPTION
Nesting these doesn't make much sense.
Let's remove the exception code and refactor the only usage to just
re-throw the already existing exception.