### PR TITLE
Use correct HTTP method for redirects

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/GitHubClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/GitHubClient.java
@@ -772,7 +772,7 @@ public class GitHubClient {
       final Request request =
           requestBuilder(newLocation)
               .url(newLocation)
-              .method("POST", response.request().body())
+              .method(response.request().method(), response.request().body())
               .build();
       // Do the new call and complete the original future when the new call completes
       return call(request);


### PR DESCRIPTION
Instead of hardcoding POST, let's use the original method when following
redirects. This fixes deleting commit comments (and other calls
potentially).

We'll add tests for this in a follow-up since it requires a non-trivial
amount of setup to test properly and we need to ship this fix ASAP.
Sorry.