### PR TITLE
added "page" and "per_page" search parameters

### DIFF
--- a/src/main/java/com/spotify/github/v3/search/requests/SearchParameters.java
+++ b/src/main/java/com/spotify/github/v3/search/requests/SearchParameters.java
@@ -20,13 +20,16 @@
 
 package com.spotify.github.v3.search.requests;
 
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+import org.immutables.value.Value;
+
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.spotify.github.GithubStyle;
 import com.spotify.github.Parameters;
-import java.util.Optional;
-import javax.annotation.Nullable;
-import org.immutables.value.Value;
 
 /**
  * Search parameters resource defines required and optional parameters. To be serialized as
@@ -47,4 +50,15 @@ public interface SearchParameters extends Parameters {
 
   /** The sort order if sort parameter is provided. One of asc or desc. Default: desc */
   Optional<String> order();
+
+  /**
+   * The number of results per page (max 100). Default: 30
+   */
+  @SuppressWarnings("checkstyle:methodname")
+  Optional<Integer> per_page();
+
+  /**
+   * Page number of the results to fetch. Default: 1
+   */
+  Optional<Integer> page();
 }

--- a/src/test/java/com/spotify/github/v3/search/requests/SearchParametersTest.java
+++ b/src/test/java/com/spotify/github/v3/search/requests/SearchParametersTest.java
@@ -40,4 +40,16 @@ public class SearchParametersTest {
 
     assertThat(params.serialize(), is("order=bogus-order&page=2&per_page=50&q=bogus-query&sort=bogus-sort"));
   }
+
+  @Test
+  public void testSerializeWithoutPageAndPerPageParameters() {
+    final SearchParameters params =
+            ImmutableSearchParameters.builder()
+                    .q("bogus-query")
+                    .sort("bogus-sort")
+                    .order("bogus-order")
+                    .build();
+
+    assertThat(params.serialize(), is("order=bogus-order&q=bogus-query&sort=bogus-sort"));
+  }
 }

--- a/src/test/java/com/spotify/github/v3/search/requests/SearchParametersTest.java
+++ b/src/test/java/com/spotify/github/v3/search/requests/SearchParametersTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,8 +34,10 @@ public class SearchParametersTest {
             .q("bogus-query")
             .sort("bogus-sort")
             .order("bogus-order")
+            .per_page(50)
+            .page(2)
             .build();
 
-    assertThat(params.serialize(), is("order=bogus-order&q=bogus-query&sort=bogus-sort"));
+    assertThat(params.serialize(), is("order=bogus-order&page=2&per_page=50&q=bogus-query&sort=bogus-sort"));
   }
 }


### PR DESCRIPTION
Hello,
Added **page** and **per_page** params
according to https://docs.github.com/en/enterprise-server@3.4/rest/search#search-repositories specification, **page** and **per_page** search params are supported
