### PR TITLE
Add repository collaborator; handle 204 response, accept permission

### DIFF
--- a/src/main/java/com/spotify/github/v3/repos/RepositoryPermission.java
+++ b/src/main/java/com/spotify/github/v3/repos/RepositoryPermission.java
@@ -1,0 +1,33 @@
+/*-
+ * -\-\-
+ * github-client
+ * --
+ * Copyright (C) 2016 - 2022 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.github.v3.repos;
+
+/** Helpful constants for Repository permissions. */
+public class RepositoryPermission {
+
+  public static final String PULL = "pull";
+  public static final String PUSH = "push";
+  public static final String ADMIN = "admin";
+  public static final String MAINTAIN = "maintain";
+  public static final String TRIAGE = "triage";
+
+  private RepositoryPermission() {}
+}


### PR DESCRIPTION
Follow-on to #97; we did not handle 204 responses from GitHub, nor accept the permission level for the added collaborator.