### PR TITLE
Serialize Annotation object with all required fields even empty

### DIFF
--- a/src/main/java/com/spotify/github/v3/checks/Annotation.java
+++ b/src/main/java/com/spotify/github/v3/checks/Annotation.java
@@ -43,7 +43,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @GithubStyle
 @JsonDeserialize(as = ImmutableAnnotation.class)
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
 public interface Annotation {
 
   /**

--- a/src/test/java/com/spotify/github/v3/checks/AnnotationTest.java
+++ b/src/test/java/com/spotify/github/v3/checks/AnnotationTest.java
@@ -24,11 +24,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.spotify.github.FixtureHelper;
 import com.spotify.github.jackson.Json;
 import com.spotify.github.v3.checks.ImmutableAnnotation.Builder;
-import java.io.IOException;
-import java.time.ZonedDateTime;
 import org.junit.Test;
 
 public class AnnotationTest {
@@ -65,5 +62,21 @@ public class AnnotationTest {
     assertThrows(IllegalStateException.class, () ->
         builder().rawDetails("a".repeat(66000)).build()
     );
+  }
+
+  @Test
+  public void serializesWithEmptyFields() {
+    Annotation annotationWithEmptyStringFields = ImmutableAnnotation.builder()
+        .message("")
+        .path("")
+        .title("")
+        .startLine(1)
+        .endLine(2)
+        .annotationLevel(AnnotationLevel.notice)
+        .build();
+
+    String serializedAnnotation = Json.create().toJsonUnchecked(annotationWithEmptyStringFields);
+    String expected = "{\"path\":\"\",\"annotation_level\":\"notice\",\"message\":\"\",\"title\":\"\",\"start_line\":1,\"end_line\":2}";
+    assertThat(serializedAnnotation, is(expected));
   }
 }


### PR DESCRIPTION
Having JsonInclude:NON_EMPTY removes empty fields (e.g., "")
When the required fields are removed, API calls fail due to missing
 fields in the request.

Let's use less restrictive JsonInclude:NON_ABSENT annotation, which
removes only null & absent fields. Required fields are anyway non-nullable.



The failing test commit https://github.com/spotify/github-java-client/pull/110/commits/5a1724f56436f8c3aff156e13205615426601585 shows how NON_EMPTY rule works
```junit
Failed tests: 
  AnnotationTest.serializesWithEmptyFields:80 
Expected: is "{\"path\":\"\",\"annotation_level\":\"notice\",\"message\":\"\",\"title\":\"\",\"start_line\":1,\"end_line\":2}"
     but: was "{\"annotation_level\":\"notice\",\"title\":\"\",\"start_line\":1,\"end_line\":2}"
```
^ from [failed build logs](https://github.com/spotify/github-java-client/runs/7706355604?check_suite_focus=true)