### PR TITLE
Fix bug #103 type for CheckRunResponse to support long id

### DIFF
--- a/src/main/java/com/spotify/github/v3/checks/CheckRunResponse.java
+++ b/src/main/java/com/spotify/github/v3/checks/CheckRunResponse.java
@@ -36,7 +36,7 @@ public interface CheckRunResponse extends CheckRunBase {
    *
    * @return the int
    */
-  int id();
+  long id();
 
   /**
    * Url string.

--- a/src/main/java/com/spotify/github/v3/clients/ChecksClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/ChecksClient.java
@@ -92,7 +92,7 @@ public class ChecksClient {
    * @param id the checkRun id
    * @return a CheckRunResponse
    */
-  public CompletableFuture<CheckRunResponse> getCheckRun(final int id) {
+  public CompletableFuture<CheckRunResponse> getCheckRun(final long id) {
     final String path = String.format(GET_CHECK_RUN_URI, owner, repo, id);
     return github.request(path, CheckRunResponse.class, extraHeaders);
   }

--- a/src/test/java/com/spotify/github/v3/clients/ChecksClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/ChecksClientTest.java
@@ -128,9 +128,24 @@ public class ChecksClientTest {
     final CompletableFuture<CheckRunResponse> actualResponse = checksClient.getCheckRun(4);
 
     assertThat(actualResponse.get().status(), is(completed));
-    assertThat(actualResponse.get().id(), is(4));
+    assertThat(actualResponse.get().id(), is(4L));
     assertThat(actualResponse.get().headSha(), is("ce587453ced02b1526dfb4cb910479d431683101"));
     assertThat(actualResponse.get().output().annotationsCount().get(), is(2));
+  }
+
+  @Test
+  public void getCompletedCheckRunWithLongId() throws Exception {
+    final CheckRunResponse checkRunResponse =
+        json.fromJson(
+            loadResource(FIXTURES_PATH + "checks-run-completed-long-id-response.json"),
+            CheckRunResponse.class);
+
+    final CompletableFuture<CheckRunResponse> fixtureResponse = completedFuture(checkRunResponse);
+    when(github.request(any(), eq(CheckRunResponse.class), any())).thenReturn(fixtureResponse);
+
+    final CompletableFuture<CheckRunResponse> actualResponse = checksClient.getCheckRun(6971753714L);
+
+    assertThat(actualResponse.get().id(), is(6971753714L));
   }
 
   @Test

--- a/src/test/resources/com/spotify/github/v3/checks/checks-run-completed-long-id-response.json
+++ b/src/test/resources/com/spotify/github/v3/checks/checks-run-completed-long-id-response.json
@@ -1,0 +1,73 @@
+{
+  "id": 6971753714,
+  "head_sha": "ce587453ced02b1526dfb4cb910479d431683101",
+  "node_id": "MDg6Q2hlY2tSdW40",
+  "external_id": "",
+  "url": "https://api.github.com/repos/github/hello-world/check-runs/6971753714",
+  "html_url": "http://github.com/github/hello-world/runs/6971753714",
+  "details_url": "https://example.com",
+  "status": "completed",
+  "conclusion": "neutral",
+  "started_at": "2018-05-04T01:14:52Z",
+  "completed_at": "2018-05-04T01:14:52Z",
+  "output": {
+    "title": "Mighty Readme report",
+    "summary": "There are 0 failures, 2 warnings, and 1 notice.",
+    "text": "You may have some misspelled words on lines 2 and 4. You also may want to add a section in your README about how to install your app.",
+    "annotations_count": 2,
+    "annotations_url": "https://api.github.com/repos/github/hello-world/check-runs/6971753714/annotations"
+  },
+  "name": "mighty_readme",
+  "check_suite": {
+    "id": 5
+  },
+  "app": {
+    "id": 1,
+    "node_id": "MDExOkludGVncmF0aW9uMQ==",
+    "owner": {
+      "login": "github",
+      "id": 1,
+      "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+      "url": "https://api.github.com/orgs/github",
+      "repos_url": "https://api.github.com/orgs/github/repos",
+      "events_url": "https://api.github.com/orgs/github/events",
+      "hooks_url": "https://api.github.com/orgs/github/hooks",
+      "issues_url": "https://api.github.com/orgs/github/issues",
+      "members_url": "https://api.github.com/orgs/github/members{/member}",
+      "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+      "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+      "description": "A great organization"
+    },
+    "name": "Super CI",
+    "description": "",
+    "external_url": "https://example.com",
+    "html_url": "https://github.com/apps/super-ci",
+    "created_at": "2017-07-08T16:18:44-04:00",
+    "updated_at": "2017-07-08T16:18:44-04:00"
+  },
+  "pull_requests": [
+    {
+      "url": "https://api.github.com/repos/github/hello-world/pulls/1",
+      "id": 1934,
+      "number": 3956,
+      "head": {
+        "ref": "say-hello",
+        "sha": "3dca65fa3e8d4b3da3f3d056c59aee1c50f41390",
+        "repo": {
+          "id": 526,
+          "url": "https://api.github.com/repos/github/hello-world",
+          "name": "hello-world"
+        }
+      },
+      "base": {
+        "ref": "master",
+        "sha": "e7fdf7640066d71ad16a86fbcbb9c6a10a18af4f",
+        "repo": {
+          "id": 526,
+          "url": "https://api.github.com/repos/github/hello-world",
+          "name": "hello-world"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
CheckRunResponse id updated to support long. We also could consider using String type in case, for example, they migrate for UUID, but in their [documentation](https://docs.github.com/en/rest/checks/runs#get-a-check-run), they handle yet as an integer which seems not to be more the case once we have numbers bigger than the supporter by int type.

Fix issue https://github.com/spotify/github-java-client/issues/103