### PR TITLE
Validate check run output text and summary length

### DIFF
--- a/src/main/java/com/spotify/github/v3/checks/CheckRunOutput.java
+++ b/src/main/java/com/spotify/github/v3/checks/CheckRunOutput.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,7 @@ package com.spotify.github.v3.checks;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.base.Preconditions;
 import com.spotify.github.GithubStyle;
 import java.util.List;
 import java.util.Optional;
@@ -87,4 +88,20 @@ public interface CheckRunOutput {
    * @return the optional
    */
   Optional<String> annotationsUrl();
+
+  /**
+   * Automatically validates the maximum length of properties.
+   * <p>
+   * GitHub does not validate these properly on their side (at least in GHE 3.2) and returns 422
+   * HTTP responses instead. To avoid that, let's validate the data in this client library.
+   */
+  @Value.Check
+  @SuppressWarnings("checkstyle:magicnumber")
+  default void check() {
+    // max values from https://docs.github.com/en/enterprise-server@3.5/rest/checks/runs#create-a-check-run
+    Preconditions.checkState(summary().map(String::length).orElse(0) <= 64 * 1024,
+        "'summary' exceeded max length of 65535 characters");
+    Preconditions.checkState(text().map(String::length).orElse(0) <= 64 * 1024,
+        "'text' exceeded max length of 65535 characters");
+  }
 }

--- a/src/main/java/com/spotify/github/v3/checks/CheckRunOutput.java
+++ b/src/main/java/com/spotify/github/v3/checks/CheckRunOutput.java
@@ -99,9 +99,9 @@ public interface CheckRunOutput {
   @SuppressWarnings("checkstyle:magicnumber")
   default void check() {
     // max values from https://docs.github.com/en/enterprise-server@3.5/rest/checks/runs#create-a-check-run
-    Preconditions.checkState(summary().map(String::length).orElse(0) <= 64 * 1024,
+    Preconditions.checkState(summary().map(String::length).orElse(0) < 64 * 1024,
         "'summary' exceeded max length of 65535 characters");
-    Preconditions.checkState(text().map(String::length).orElse(0) <= 64 * 1024,
+    Preconditions.checkState(text().map(String::length).orElse(0) < 64 * 1024,
         "'text' exceeded max length of 65535 characters");
   }
 }

--- a/src/main/java/com/spotify/github/v3/checks/CheckRunOutput.java
+++ b/src/main/java/com/spotify/github/v3/checks/CheckRunOutput.java
@@ -99,9 +99,9 @@ public interface CheckRunOutput {
   @SuppressWarnings("checkstyle:magicnumber")
   default void check() {
     // max values from https://docs.github.com/en/enterprise-server@3.5/rest/checks/runs#create-a-check-run
-    Preconditions.checkState(summary().map(String::length).orElse(0) < 64 * 1024,
+    Preconditions.checkState(summary().map(String::length).orElse(0) <= 65535,
         "'summary' exceeded max length of 65535 characters");
-    Preconditions.checkState(text().map(String::length).orElse(0) < 64 * 1024,
+    Preconditions.checkState(text().map(String::length).orElse(0) <= 65535,
         "'text' exceeded max length of 65535 characters");
   }
 }

--- a/src/test/java/com/spotify/github/v3/checks/CheckRunOutputTest.java
+++ b/src/test/java/com/spotify/github/v3/checks/CheckRunOutputTest.java
@@ -22,38 +22,28 @@ package com.spotify.github.v3.checks;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.spotify.github.v3.checks.ImmutableCheckRunAction.Builder;
+import com.spotify.github.v3.checks.ImmutableCheckRunOutput.Builder;
 import org.junit.Test;
 
-public class CheckRunActionTest {
+public class CheckRunOutputTest {
+
   private Builder builder() {
-    return ImmutableCheckRunAction.builder()
-        .label("label")
-        .identifier("identifier")
-        .description("description");
+    return ImmutableCheckRunOutput.builder();
   }
 
   @Test
-  public void allowsCreationWithinLimits(){
+  public void allowsCreationWithinLimits() {
     builder().build();
-
     builder()
-        .label("a".repeat(20))
-        .identifier("a".repeat(20))
-        .description("a".repeat(40))
-        .build();
+        .text("t".repeat((64 * 1024) - 1)).summary("s".repeat((1024 * 64) - 1)).build();
   }
 
   @Test
-  public void failsCreationWhenMaxLengthExceeded(){
-    assertThrows(IllegalStateException.class, () ->
-        builder().label("a".repeat(21)).build()
-    );
-    assertThrows(IllegalStateException.class, () ->
-        builder().identifier("a".repeat(21)).build()
-    );
-    assertThrows(IllegalStateException.class, () ->
-        builder().description("a".repeat(41)).build()
-    );
+  public void failsCreationWhenMaxLengthExceeded() {
+    assertThrows(IllegalStateException.class,
+        () -> builder().text("t".repeat(64 * 1024)).build());
+    assertThrows(IllegalStateException.class,
+        () -> builder().summary("s".repeat(64 * 1024)).build());
   }
 }
+

--- a/src/test/java/com/spotify/github/v3/checks/CheckRunOutputTest.java
+++ b/src/test/java/com/spotify/github/v3/checks/CheckRunOutputTest.java
@@ -35,15 +35,15 @@ public class CheckRunOutputTest {
   public void allowsCreationWithinLimits() {
     builder().build();
     builder()
-        .text("t".repeat((64 * 1024) - 1)).summary("s".repeat((1024 * 64) - 1)).build();
+        .text("t".repeat(65535)).summary("s".repeat(65535)).build();
   }
 
   @Test
   public void failsCreationWhenMaxLengthExceeded() {
     assertThrows(IllegalStateException.class,
-        () -> builder().text("t".repeat(64 * 1024)).build());
+        () -> builder().text("t".repeat(65536)).build());
     assertThrows(IllegalStateException.class,
-        () -> builder().summary("s".repeat(64 * 1024)).build());
+        () -> builder().summary("s".repeat(65536)).build());
   }
 }
 


### PR DESCRIPTION
Automatically validates the maximum length of check run `output` properties.

GitHub does not validate these properly on their side (at least in GHE 3.2)
and returns 422 HTTP responses instead. To avoid that, let's validate the data
in this client library.

The values are taken from the [official GitHub documentation](https://docs.github.com/en/enterprise-server@3.5/rest/checks/runs#create-a-check-run)