### PR TITLE
Add create and update file to RepositoryClient

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
@@ -395,7 +395,7 @@ public class RepositoryClient {
    */
   public CompletableFuture<FileCommit> updateFile(final String path, final FileUpdate fileUpdate) {
     final String requestBody = github.json().toJsonUnchecked(fileUpdate);
-    return github.post(getContentPath(path, ""), requestBody, FileCommit.class);
+    return github.put(getContentPath(path, ""), requestBody, FileCommit.class);
   }
 
   /**
@@ -407,7 +407,7 @@ public class RepositoryClient {
    */
   public CompletableFuture<FileCommit> createFile(final String path, final FileCreate fileCreate) {
     final String requestBody = github.json().toJsonUnchecked(fileCreate);
-    return github.post(getContentPath(path, ""), requestBody, FileCommit.class);
+    return github.put(getContentPath(path, ""), requestBody, FileCommit.class);
   }
 
   /**

--- a/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
@@ -37,18 +37,10 @@ import com.spotify.github.v3.exceptions.RequestNotOkException;
 import com.spotify.github.v3.git.Tree;
 import com.spotify.github.v3.hooks.requests.WebhookCreate;
 import com.spotify.github.v3.prs.PullRequestItem;
-import com.spotify.github.v3.repos.Branch;
-import com.spotify.github.v3.repos.Commit;
-import com.spotify.github.v3.repos.CommitComparison;
-import com.spotify.github.v3.repos.CommitItem;
-import com.spotify.github.v3.repos.CommitStatus;
-import com.spotify.github.v3.repos.Content;
-import com.spotify.github.v3.repos.FolderContent;
-import com.spotify.github.v3.repos.Languages;
-import com.spotify.github.v3.repos.Repository;
-import com.spotify.github.v3.repos.RepositoryInvitation;
-import com.spotify.github.v3.repos.Status;
+import com.spotify.github.v3.repos.*;
 import com.spotify.github.v3.repos.requests.AuthenticatedUserRepositoriesFilter;
+import com.spotify.github.v3.repos.requests.FileCreate;
+import com.spotify.github.v3.repos.requests.FileUpdate;
 import com.spotify.github.v3.repos.requests.RepositoryCreateStatus;
 import java.lang.invoke.MethodHandles;
 import java.util.Iterator;
@@ -245,7 +237,7 @@ public class RepositoryClient {
   /**
    * Create a webhook.
    *
-   * @param request create request
+   * @param request        create request
    * @param ignoreExisting if true hook exists errors will be ignored
    */
   public CompletableFuture<Void> createWebhook(
@@ -276,7 +268,7 @@ public class RepositoryClient {
   /**
    * Set status for a given commit.
    *
-   * @param sha the commit sha to set the status for
+   * @param sha     the commit sha to set the status for
    * @param request The body of the request to sent to github to create a commit status
    */
   public CompletableFuture<Void> setCommitStatus(
@@ -312,7 +304,7 @@ public class RepositoryClient {
    * List statuses for a specific ref. Statuses are returned in reverse chronological order. The
    * first status in the list will be the latest one.
    *
-   * @param sha the commit sha to list the statuses for
+   * @param sha          the commit sha to list the statuses for
    * @param itemsPerPage number of items per page
    * @return iterator of Status
    */
@@ -387,11 +379,35 @@ public class RepositoryClient {
    * Get repository contents of a file.
    *
    * @param path path to a file
-   * @param ref name of the commit/branch/tag
+   * @param ref  name of the commit/branch/tag
    * @return content
    */
   public CompletableFuture<Content> getFileContent(final String path, final String ref) {
     return github.request(getContentPath(path, "?ref=" + ref), Content.class);
+  }
+
+  /**
+   * Update file in the repository.
+   *
+   * @param path       the path
+   * @param fileUpdate the file update
+   * @return the completable future
+   */
+  public CompletableFuture<FileCommit> updateFile(final String path, final FileUpdate fileUpdate) {
+    final String requestBody = github.json().toJsonUnchecked(fileUpdate);
+    return github.post(getContentPath(path, ""), requestBody, FileCommit.class);
+  }
+
+  /**
+   * Create file in the repository.
+   *
+   * @param path       the path
+   * @param fileCreate the file create
+   * @return the completable future
+   */
+  public CompletableFuture<FileCommit> createFile(final String path, final FileCreate fileCreate) {
+    final String requestBody = github.json().toJsonUnchecked(fileCreate);
+    return github.post(getContentPath(path, ""), requestBody, FileCommit.class);
   }
 
   /**
@@ -407,7 +423,7 @@ public class RepositoryClient {
   /**
    * Create a comment for a given issue number.
    *
-   * @param sha the commit sha to create the comment on
+   * @param sha  the commit sha to create the comment on
    * @param body comment content
    * @return the Comment that was just created
    */
@@ -432,7 +448,7 @@ public class RepositoryClient {
    * Get repository contents of a folder.
    *
    * @param path path to a folder
-   * @param ref name of the commit/branch/tag
+   * @param ref  name of the commit/branch/tag
    * @return content
    */
   public CompletableFuture<List<FolderContent>> getFolderContent(

--- a/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
@@ -37,7 +37,19 @@ import com.spotify.github.v3.exceptions.RequestNotOkException;
 import com.spotify.github.v3.git.Tree;
 import com.spotify.github.v3.hooks.requests.WebhookCreate;
 import com.spotify.github.v3.prs.PullRequestItem;
-import com.spotify.github.v3.repos.*;
+
+import com.spotify.github.v3.repos.Branch;
+import com.spotify.github.v3.repos.Commit;
+import com.spotify.github.v3.repos.CommitComparison;
+import com.spotify.github.v3.repos.CommitItem;
+import com.spotify.github.v3.repos.CommitStatus;
+import com.spotify.github.v3.repos.Content;
+import com.spotify.github.v3.repos.FileCommit;
+import com.spotify.github.v3.repos.FolderContent;
+import com.spotify.github.v3.repos.Languages;
+import com.spotify.github.v3.repos.Repository;
+import com.spotify.github.v3.repos.RepositoryInvitation;
+import com.spotify.github.v3.repos.Status;
 import com.spotify.github.v3.repos.requests.AuthenticatedUserRepositoriesFilter;
 import com.spotify.github.v3.repos.requests.FileCreate;
 import com.spotify.github.v3.repos.requests.FileUpdate;
@@ -191,7 +203,7 @@ public class RepositoryClient {
    * @return
    */
   public CompletableFuture<Optional<RepositoryInvitation>> addCollaborator(final String user,
-      final String permission) {
+                                                                           final String permission) {
     final String path = String.format(REPOSITORY_COLLABORATOR, owner, repo, user);
     final String data = github.json().toJsonUnchecked(Map.of("permission", permission));
     return github

--- a/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
@@ -37,7 +37,6 @@ import com.spotify.github.v3.exceptions.RequestNotOkException;
 import com.spotify.github.v3.git.Tree;
 import com.spotify.github.v3.hooks.requests.WebhookCreate;
 import com.spotify.github.v3.prs.PullRequestItem;
-
 import com.spotify.github.v3.repos.Branch;
 import com.spotify.github.v3.repos.Commit;
 import com.spotify.github.v3.repos.CommitComparison;
@@ -203,7 +202,7 @@ public class RepositoryClient {
    * @return
    */
   public CompletableFuture<Optional<RepositoryInvitation>> addCollaborator(final String user,
-                                                                           final String permission) {
+      final String permission) {
     final String path = String.format(REPOSITORY_COLLABORATOR, owner, repo, user);
     final String data = github.json().toJsonUnchecked(Map.of("permission", permission));
     return github
@@ -249,7 +248,7 @@ public class RepositoryClient {
   /**
    * Create a webhook.
    *
-   * @param request        create request
+   * @param request create request
    * @param ignoreExisting if true hook exists errors will be ignored
    */
   public CompletableFuture<Void> createWebhook(
@@ -280,7 +279,7 @@ public class RepositoryClient {
   /**
    * Set status for a given commit.
    *
-   * @param sha     the commit sha to set the status for
+   * @param sha the commit sha to set the status for
    * @param request The body of the request to sent to github to create a commit status
    */
   public CompletableFuture<Void> setCommitStatus(
@@ -316,7 +315,7 @@ public class RepositoryClient {
    * List statuses for a specific ref. Statuses are returned in reverse chronological order. The
    * first status in the list will be the latest one.
    *
-   * @param sha          the commit sha to list the statuses for
+   * @param sha the commit sha to list the statuses for
    * @param itemsPerPage number of items per page
    * @return iterator of Status
    */
@@ -391,7 +390,7 @@ public class RepositoryClient {
    * Get repository contents of a file.
    *
    * @param path path to a file
-   * @param ref  name of the commit/branch/tag
+   * @param ref name of the commit/branch/tag
    * @return content
    */
   public CompletableFuture<Content> getFileContent(final String path, final String ref) {
@@ -435,7 +434,7 @@ public class RepositoryClient {
   /**
    * Create a comment for a given issue number.
    *
-   * @param sha  the commit sha to create the comment on
+   * @param sha the commit sha to create the comment on
    * @param body comment content
    * @return the Comment that was just created
    */
@@ -460,7 +459,7 @@ public class RepositoryClient {
    * Get repository contents of a folder.
    *
    * @param path path to a folder
-   * @param ref  name of the commit/branch/tag
+   * @param ref name of the commit/branch/tag
    * @return content
    */
   public CompletableFuture<List<FolderContent>> getFolderContent(

--- a/src/main/java/com/spotify/github/v3/repos/FileCommit.java
+++ b/src/main/java/com/spotify/github/v3/repos/FileCommit.java
@@ -1,0 +1,39 @@
+/*-
+ * -\-\-
+ * github-api
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.github.v3.repos;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.spotify.github.GithubStyle;
+import com.spotify.github.v3.git.Commit;
+import org.immutables.value.Value;
+
+
+@Value.Immutable
+@GithubStyle
+@JsonSerialize(as = ImmutableFileCommit.class)
+@JsonDeserialize(as = ImmutableFileCommit.class)
+public interface FileCommit {
+
+    Content content();
+
+    Commit commit();
+}

--- a/src/main/java/com/spotify/github/v3/repos/requests/FileCreate.java
+++ b/src/main/java/com/spotify/github/v3/repos/requests/FileCreate.java
@@ -1,0 +1,55 @@
+/*-
+ * -\-\-
+ * github-api
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+
+package com.spotify.github.v3.repos.requests;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.spotify.github.GithubStyle;
+import com.spotify.github.v3.git.Author;
+import org.immutables.value.Value;
+
+import javax.annotation.Nullable;
+
+@Value.Immutable
+@GithubStyle
+@JsonSerialize(as = ImmutableFileCreate.class)
+@JsonDeserialize(as = ImmutableFileCreate.class)
+public interface FileCreate {
+
+    /** The commit message. */
+    String message();
+
+    /** Committer commit user. */
+    @Nullable
+    Author committer();
+
+    /** The author of the file. Default: The committer or the authenticated user if you omit.  */
+    @Nullable
+    Author author();
+
+    /** The branch name. Default: the repository’s default branch (usually master) */
+    @Nullable
+    String branch();
+
+    /** The new file content, using Base64 encoding.. */
+    String content();
+}

--- a/src/main/java/com/spotify/github/v3/repos/requests/FileUpdate.java
+++ b/src/main/java/com/spotify/github/v3/repos/requests/FileUpdate.java
@@ -1,0 +1,58 @@
+/*-
+ * -\-\-
+ * github-api
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+
+package com.spotify.github.v3.repos.requests;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.spotify.github.GithubStyle;
+import com.spotify.github.v3.git.Author;
+import org.immutables.value.Value;
+
+import javax.annotation.Nullable;
+
+@Value.Immutable
+@GithubStyle
+@JsonSerialize(as = ImmutableFileUpdate.class)
+@JsonDeserialize(as = ImmutableFileUpdate.class)
+public interface FileUpdate {
+
+    /** The commit message. */
+    String message();
+
+    /** Committer commit user. */
+    @Nullable
+    Author committer();
+
+    /** The author of the file. Default: The committer or the authenticated user if you omit.  */
+    @Nullable
+    Author author();
+
+    /** The branch name. Default: the repository’s default branch (usually master) */
+    @Nullable
+    String branch();
+
+    /** The new file content, using Base64 encoding. */
+    String content();
+
+    /** The blob SHA of the file being replaced. */
+    String sha();
+}

--- a/src/test/java/com/spotify/github/v3/repos/FileCreateTest.java
+++ b/src/test/java/com/spotify/github/v3/repos/FileCreateTest.java
@@ -1,0 +1,79 @@
+/*-
+ * -\-\-
+ * github-client
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.github.v3.repos;
+
+import com.google.common.io.Resources;
+import com.spotify.github.GitHubInstant;
+import com.spotify.github.jackson.Json;
+import com.spotify.github.v3.git.ImmutableShaLink;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+
+import static com.google.common.io.Resources.getResource;
+import static java.nio.charset.Charset.defaultCharset;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+
+
+public class FileCreateTest {
+
+    private String fixture;
+
+    @Before
+    public void setUp() throws Exception {
+        fixture =
+                Resources.toString(getResource(this.getClass(), "file_create.json"), defaultCharset());
+    }
+
+    @Test
+    public void testDeserialization() throws IOException {
+        final FileCommit fileCommit = Json.create().fromJson(fixture, FileCommit.class);
+        assertThat(fileCommit.content(), not(nullValue()));
+        assertThat(fileCommit.content().name(), is("hello.txt"));
+        assertThat(fileCommit.content().path(), is("notes/hello.txt"));
+        assertThat(fileCommit.content().sha(), is("a56507ed892d05a37c6d6128c260937ea4d287bd"));
+        assertThat(fileCommit.content().size(), is(9));
+        assertThat(fileCommit.content().url(), is(URI.create("https://api.github.com/repos/octocat/Hello-World/contents/notes/hello.txt")));
+        assertThat(fileCommit.content().htmlUrl(), is(URI.create("https://github.com/octocat/Hello-World/blob/master/notes/hello.txt")));
+        assertThat(fileCommit.content().gitUrl(), is(URI.create("https://api.github.com/repos/octocat/Hello-World/git/blobs/a56507ed892d05a37c6d6128c260937ea4d287bd")));
+        assertThat(fileCommit.content().downloadUrl(), is(URI.create("https://raw.githubusercontent.com/octocat/HelloWorld/master/notes/hello.txt")));
+        assertThat(fileCommit.content().type(), is("file"));
+        assertThat(fileCommit.commit(), not(nullValue()));
+
+        assertThat(fileCommit.commit().sha().isPresent(), is(true));
+        assertThat(fileCommit.commit().sha().get(), is("18a43cd8e1e3a79c786e3d808a73d23b6d212b16"));
+        assertThat(fileCommit.commit().url(), is(URI.create("https://api.github.com/repos/octocat/Hello-World/git/commits/18a43cd8e1e3a79c786e3d808a73d23b6d212b16")));
+        assertThat(fileCommit.commit().author(), not(nullValue()));
+        assertThat(fileCommit.commit().author().date().isPresent(), is(true));
+        assertThat(fileCommit.commit().author().date().get().instant(), is(GitHubInstant.create(Instant.parse("2014-11-07T22:01:45Z")).instant()));
+        assertThat(fileCommit.commit().author().name(), is("Monalisa Octocat"));
+        assertThat(fileCommit.commit().author().email().isPresent(), is(true));
+        assertThat(fileCommit.commit().author().email().get(), is("octocat@github.com"));
+        assertThat(fileCommit.commit().message(), is("my commit message"));
+        assertThat(fileCommit.commit().tree(), is(ImmutableShaLink.builder().url(URI.create("https://api.github.com/repos/octocat/Hello-World/git/trees/9a21f8e2018f42ffcf369b24d2cd20bc25c9e66f")).sha("9a21f8e2018f42ffcf369b24d2cd20bc25c9e66f").build()));
+    }
+}

--- a/src/test/java/com/spotify/github/v3/repos/FileUpdateTest.java
+++ b/src/test/java/com/spotify/github/v3/repos/FileUpdateTest.java
@@ -1,0 +1,79 @@
+/*-
+ * -\-\-
+ * github-client
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.github.v3.repos;
+
+import com.google.common.io.Resources;
+import com.spotify.github.GitHubInstant;
+import com.spotify.github.jackson.Json;
+import com.spotify.github.v3.git.ImmutableShaLink;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+
+import static com.google.common.io.Resources.getResource;
+import static java.nio.charset.Charset.defaultCharset;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+
+
+public class FileUpdateTest {
+
+    private String fixture;
+
+    @Before
+    public void setUp() throws Exception {
+        fixture =
+                Resources.toString(getResource(this.getClass(), "file_update.json"), defaultCharset());
+    }
+
+    @Test
+    public void testDeserialization() throws IOException {
+        final FileCommit fileCommit = Json.create().fromJson(fixture, FileCommit.class);
+        assertThat(fileCommit.content(), not(nullValue()));
+        assertThat(fileCommit.content().name(), is("hello.txt"));
+        assertThat(fileCommit.content().path(), is("notes/hello.txt"));
+        assertThat(fileCommit.content().sha(), is("95b966ae1c166bd92f8ae7d1c313e738c731dfc3"));
+        assertThat(fileCommit.content().size(), is(9));
+        assertThat(fileCommit.content().url(), is(URI.create("https://api.github.com/repos/octocat/Hello-World/contents/notes/hello.txt")));
+        assertThat(fileCommit.content().htmlUrl(), is(URI.create("https://github.com/octocat/Hello-World/blob/master/notes/hello.txt")));
+        assertThat(fileCommit.content().gitUrl(), is(URI.create("https://api.github.com/repos/octocat/Hello-World/git/blobs/95b966ae1c166bd92f8ae7d1c313e738c731dfc3")));
+        assertThat(fileCommit.content().downloadUrl(), is(URI.create("https://raw.githubusercontent.com/octocat/HelloWorld/master/notes/hello.txt")));
+        assertThat(fileCommit.content().type(), is("file"));
+        assertThat(fileCommit.commit(), not(nullValue()));
+
+        assertThat(fileCommit.commit().sha().isPresent(), is(true));
+        assertThat(fileCommit.commit().sha().get(), is("7638417db6d59f3c431d3e1f261cc637155684cd"));
+        assertThat(fileCommit.commit().url(), is(URI.create("https://api.github.com/repos/octocat/Hello-World/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd")));
+        assertThat(fileCommit.commit().author(), not(nullValue()));
+        assertThat(fileCommit.commit().author().date().isPresent(), is(true));
+        assertThat(fileCommit.commit().author().date().get().instant(), is(GitHubInstant.create(Instant.parse("2014-11-07T22:01:45Z")).instant()));
+        assertThat(fileCommit.commit().author().name(), is("Monalisa Octocat"));
+        assertThat(fileCommit.commit().author().email().isPresent(), is(true));
+        assertThat(fileCommit.commit().author().email().get(), is("octocat@github.com"));
+        assertThat(fileCommit.commit().message(), is("my commit message"));
+        assertThat(fileCommit.commit().tree(), is(ImmutableShaLink.builder().url(URI.create("https://api.github.com/repos/octocat/Hello-World/git/trees/691272480426f78a0138979dd3ce63b77f706feb")).sha("691272480426f78a0138979dd3ce63b77f706feb").build()));
+    }
+}

--- a/src/test/java/com/spotify/github/v3/repos/requests/RepositoryFileCreateTest.java
+++ b/src/test/java/com/spotify/github/v3/repos/requests/RepositoryFileCreateTest.java
@@ -1,0 +1,50 @@
+/*-
+ * -\-\-
+ * github-api
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+
+package com.spotify.github.v3.repos.requests;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.spotify.github.jackson.Json;
+import com.spotify.github.v3.git.ImmutableAuthor;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class RepositoryFileCreateTest {
+
+    @Test
+    public void testSerializeFileCreateRequest() {
+
+        final FileCreate request =
+                ImmutableFileCreate.builder()
+                        .message("my commit message")
+                        .committer( ImmutableAuthor.builder().name("Monalisa Octocat").email("octocat@github.com").build())
+                        .content("bXkgbmV3IGZpbGUgY29udGVudHM=")
+                        .build();
+        assertThat(
+                Json.create().toJsonUnchecked(request),
+                is(
+                        equalTo(
+                                "{\"message\":\"my commit message\",\"committer\":{\"name\":\"Monalisa Octocat\",\"email\":\"octocat@github.com\",\"username\":null,\"date\":null},\"content\":\"bXkgbmV3IGZpbGUgY29udGVudHM=\"}")));
+    }
+}

--- a/src/test/java/com/spotify/github/v3/repos/requests/RepositoryFileUpdateTest.java
+++ b/src/test/java/com/spotify/github/v3/repos/requests/RepositoryFileUpdateTest.java
@@ -1,0 +1,51 @@
+/*-
+ * -\-\-
+ * github-api
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+
+package com.spotify.github.v3.repos.requests;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.spotify.github.jackson.Json;
+import com.spotify.github.v3.git.ImmutableAuthor;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class RepositoryFileUpdateTest {
+
+    @Test
+    public void testSerializeFileUpdateRequest() {
+
+        final FileUpdate request =
+                ImmutableFileUpdate.builder()
+                        .message("my commit message")
+                        .committer( ImmutableAuthor.builder().name("Monalisa Octocat").email("octocat@github.com").build())
+                        .content("bXkgbmV3IGZpbGUgY29udGVudHM=")
+                        .sha("95b966ae1c166bd92f8ae7d1c313e738c731dfc3")
+                        .build();
+        assertThat(
+                Json.create().toJsonUnchecked(request),
+                is(
+                        equalTo(
+                                "{\"message\":\"my commit message\",\"committer\":{\"name\":\"Monalisa Octocat\",\"email\":\"octocat@github.com\",\"username\":null,\"date\":null},\"content\":\"bXkgbmV3IGZpbGUgY29udGVudHM=\",\"sha\":\"95b966ae1c166bd92f8ae7d1c313e738c731dfc3\"}")));
+    }
+}

--- a/src/test/resources/com/spotify/github/v3/repos/file_create.json
+++ b/src/test/resources/com/spotify/github/v3/repos/file_create.json
@@ -1,0 +1,52 @@
+{
+  "content": {
+    "name": "hello.txt",
+    "path": "notes/hello.txt",
+    "sha": "a56507ed892d05a37c6d6128c260937ea4d287bd",
+    "size": 9,
+    "url": "https://api.github.com/repos/octocat/Hello-World/contents/notes/hello.txt",
+    "html_url": "https://github.com/octocat/Hello-World/blob/master/notes/hello.txt",
+    "git_url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/a56507ed892d05a37c6d6128c260937ea4d287bd",
+    "download_url": "https://raw.githubusercontent.com/octocat/HelloWorld/master/notes/hello.txt",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/octocat/Hello-World/contents/notes/hello.txt",
+      "git": "https://api.github.com/repos/octocat/Hello-World/git/blobs/a56507ed892d05a37c6d6128c260937ea4d287bd",
+      "html": "https://github.com/octocat/Hello-World/blob/master/notes/hello.txt"
+    }
+  },
+  "commit": {
+    "sha": "18a43cd8e1e3a79c786e3d808a73d23b6d212b16",
+    "node_id": "MDY6Q29tbWl0MThhNDNjZDhlMWUzYTc5Yzc4NmUzZDgwOGE3M2QyM2I2ZDIxMmIxNg==",
+    "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/18a43cd8e1e3a79c786e3d808a73d23b6d212b16",
+    "html_url": "https://github.com/octocat/Hello-World/git/commit/18a43cd8e1e3a79c786e3d808a73d23b6d212b16",
+    "author": {
+      "date": "2014-11-07T22:01:45Z",
+      "name": "Monalisa Octocat",
+      "email": "octocat@github.com"
+    },
+    "committer": {
+      "date": "2014-11-07T22:01:45Z",
+      "name": "Monalisa Octocat",
+      "email": "octocat@github.com"
+    },
+    "message": "my commit message",
+    "tree": {
+      "url": "https://api.github.com/repos/octocat/Hello-World/git/trees/9a21f8e2018f42ffcf369b24d2cd20bc25c9e66f",
+      "sha": "9a21f8e2018f42ffcf369b24d2cd20bc25c9e66f"
+    },
+    "parents": [
+      {
+        "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/da5a433788da5c255edad7979b328b67d79f53f6",
+        "html_url": "https://github.com/octocat/Hello-World/git/commit/da5a433788da5c255edad7979b328b67d79f53f6",
+        "sha": "da5a433788da5c255edad7979b328b67d79f53f6"
+      }
+    ],
+    "verification": {
+      "verified": false,
+      "reason": "unsigned",
+      "signature": null,
+      "payload": null
+    }
+  }
+}

--- a/src/test/resources/com/spotify/github/v3/repos/file_update.json
+++ b/src/test/resources/com/spotify/github/v3/repos/file_update.json
@@ -1,0 +1,52 @@
+{
+  "content": {
+    "name": "hello.txt",
+    "path": "notes/hello.txt",
+    "sha": "95b966ae1c166bd92f8ae7d1c313e738c731dfc3",
+    "size": 9,
+    "url": "https://api.github.com/repos/octocat/Hello-World/contents/notes/hello.txt",
+    "html_url": "https://github.com/octocat/Hello-World/blob/master/notes/hello.txt",
+    "git_url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/95b966ae1c166bd92f8ae7d1c313e738c731dfc3",
+    "download_url": "https://raw.githubusercontent.com/octocat/HelloWorld/master/notes/hello.txt",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/octocat/Hello-World/contents/notes/hello.txt",
+      "git": "https://api.github.com/repos/octocat/Hello-World/git/blobs/95b966ae1c166bd92f8ae7d1c313e738c731dfc3",
+      "html": "https://github.com/octocat/Hello-World/blob/master/notes/hello.txt"
+    }
+  },
+  "commit": {
+    "sha": "7638417db6d59f3c431d3e1f261cc637155684cd",
+    "node_id": "MDY6Q29tbWl0NzYzODQxN2RiNmQ1OWYzYzQzMWQzZTFmMjYxY2M2MzcxNTU2ODRjZA==",
+    "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd",
+    "html_url": "https://github.com/octocat/Hello-World/git/commit/7638417db6d59f3c431d3e1f261cc637155684cd",
+    "author": {
+      "date": "2014-11-07T22:01:45Z",
+      "name": "Monalisa Octocat",
+      "email": "octocat@github.com"
+    },
+    "committer": {
+      "date": "2014-11-07T22:01:45Z",
+      "name": "Monalisa Octocat",
+      "email": "octocat@github.com"
+    },
+    "message": "my commit message",
+    "tree": {
+      "url": "https://api.github.com/repos/octocat/Hello-World/git/trees/691272480426f78a0138979dd3ce63b77f706feb",
+      "sha": "691272480426f78a0138979dd3ce63b77f706feb"
+    },
+    "parents": [
+      {
+        "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/1acc419d4d6a9ce985db7be48c6349a0475975b5",
+        "html_url": "https://github.com/octocat/Hello-World/git/commit/1acc419d4d6a9ce985db7be48c6349a0475975b5",
+        "sha": "1acc419d4d6a9ce985db7be48c6349a0475975b5"
+      }
+    ],
+    "verification": {
+      "verified": false,
+      "reason": "unsigned",
+      "signature": null,
+      "payload": null
+    }
+  }
+}


### PR DESCRIPTION
Add methods to create and update a file.

GitHub API -> https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#create-or-update-file-contents