### PR TITLE
Update check ID type

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/ChecksClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/ChecksClient.java
@@ -84,7 +84,7 @@ public class ChecksClient {
    * @return the completable future
    */
   public CompletableFuture<CheckRunResponse> updateCheckRun(
-      final int id, final CheckRunRequest checkRun) {
+      final long id, final CheckRunRequest checkRun) {
     final String path = String.format(GET_CHECK_RUN_URI, owner, repo, id);
     return github.patch(
         path, github.json().toJsonUnchecked(checkRun), CheckRunResponse.class, extraHeaders);

--- a/src/test/java/com/spotify/github/v3/clients/GitHubAuthTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/GitHubAuthTest.java
@@ -186,7 +186,7 @@ public class GitHubAuthTest {
     mockServer.enqueue(validTokenResponse);
     mockServer.enqueue(checkRunResponse);
 
-    checksClient.updateCheckRun(12, null).join();
+    checksClient.updateCheckRun(12L, null).join();
     assertThat(mockServer.getRequestCount(), is(2));
 
     assertThat(mockServer.takeRequest().getPath(), is("/app/installations/1/access_tokens"));


### PR DESCRIPTION
Check ID type is changed from `int` to `long` in [this PR](https://github.com/spotify/github-java-client/pull/114) 

This PR changes the method parameter for `updateCheckRun` from `int` to `long` to follow the changes and avoid lossy conversions in method invocations. 