### PR TITLE
increased EXPIRY_MARGIN_IN_MINUTES in GitHubClient from 3 to 5 mins

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/GitHubClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/GitHubClient.java
@@ -67,7 +67,7 @@ import org.slf4j.LoggerFactory;
  */
 public class GitHubClient {
 
-  private static final int EXPIRY_MARGIN_IN_MINUTES = 3;
+  private static final int EXPIRY_MARGIN_IN_MINUTES = 5;
 
   private Tracer tracer = NoopTracer.INSTANCE;
 


### PR DESCRIPTION
We had some issues with temporary 401s. Refreshing the token a bit earlier now and will monitor if it fixes the issue.