### PR TITLE
Omit start_column, end_column for multi-line annotation

### DIFF
--- a/src/main/java/com/spotify/github/v3/checks/Annotation.java
+++ b/src/main/java/com/spotify/github/v3/checks/Annotation.java
@@ -125,7 +125,7 @@ public interface Annotation {
    */
   @Value.Check
   @SuppressWarnings("checkstyle:magicnumber")
-  default void check() {
+  default Annotation check() {
     // max values from https://docs.github.com/en/rest/checks/runs
     Preconditions.checkState(title().map(String::length).orElse(0) <= 255,
         "'title' exceeded max length of 255");
@@ -133,5 +133,16 @@ public interface Annotation {
         "'message' exceeded max length of 64kB");
     Preconditions.checkState(rawDetails().map(String::length).orElse(0) <= 64 * 1024,
         "'rawDetails' exceeded max length of 64kB");
+
+    // Omit this (start_column, end_column) parameter if start_line and end_line have different values
+    // from https://docs.github.com/en/rest/checks/runs
+    if (startLine() != endLine()) {
+      return ImmutableAnnotation.builder()
+          .from(this)
+          .startColumn(Optional.empty())
+          .endColumn(Optional.empty())
+          .build();
+    }
+    return this;
   }
 }

--- a/src/main/java/com/spotify/github/v3/checks/Annotation.java
+++ b/src/main/java/com/spotify/github/v3/checks/Annotation.java
@@ -136,7 +136,7 @@ public interface Annotation {
 
     // Omit this (start_column, end_column) parameter if start_line and end_line have different values
     // from https://docs.github.com/en/rest/checks/runs
-    if (startLine() != endLine()) {
+    if (startLine() != endLine() && (startColumn().isPresent() || endColumn().isPresent())) {
       return ImmutableAnnotation.builder()
           .from(this)
           .startColumn(Optional.empty())

--- a/src/test/java/com/spotify/github/v3/checks/AnnotationTest.java
+++ b/src/test/java/com/spotify/github/v3/checks/AnnotationTest.java
@@ -22,10 +22,13 @@ package com.spotify.github.v3.checks;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.spotify.github.jackson.Json;
 import com.spotify.github.v3.checks.ImmutableAnnotation.Builder;
+import java.util.Optional;
 import org.junit.Test;
 
 public class AnnotationTest {
@@ -84,13 +87,20 @@ public class AnnotationTest {
 
   @Test
   public void clearsColumnFieldsForMultiLineAnnotation() {
-    Annotation annotationSpanningMultipleLines = builder().startLine(1).endLine(2).build();
-    String serializedAnnotation = Json.create().toJsonUnchecked(annotationSpanningMultipleLines);
-    String serializedWithoutColumns = "{\"path\":\"path\",\"annotation_level\":\"notice\",\"message\":\"message\",\"title\":\"title\",\"raw_details\":\"rawDetails\",\"start_line\":1,\"end_line\":2";
-    assertThat(serializedAnnotation, is(serializedWithoutColumns + "}"));
+    Annotation multiLineAnnotation = builder().startLine(1).endLine(2).build();
+    assertTrue(multiLineAnnotation.startColumn().isEmpty());
+    assertTrue(multiLineAnnotation.endColumn().isEmpty());
 
-    Annotation annotationOnSingleLine = builder().startLine(1).endLine(1).build();
-    serializedAnnotation = Json.create().toJsonUnchecked(annotationOnSingleLine);
-    assertThat(serializedAnnotation, is(serializedWithoutColumns + ",\"start_column\":1,\"end_column\":9}"));
+    Annotation anotherMultiLineAnnotation = builder().startLine(1).endLine(2).startColumn(Optional.empty()).endColumn(1).build();
+    assertTrue(anotherMultiLineAnnotation.startColumn().isEmpty());
+    assertTrue(anotherMultiLineAnnotation.endColumn().isEmpty());
+
+    Annotation yetAnotherMultiLineAnnotation = builder().startLine(1).endLine(2).startColumn(1).endColumn(Optional.empty()).build();
+    assertTrue(yetAnotherMultiLineAnnotation.startColumn().isEmpty());
+    assertTrue(yetAnotherMultiLineAnnotation.endColumn().isEmpty());
+
+    Annotation singleLineAnnotation = builder().startLine(1).endLine(1).build();
+    assertEquals(1, singleLineAnnotation.startColumn().orElse(0));
+    assertEquals(9, singleLineAnnotation.endColumn().orElse(0));
   }
 }

--- a/src/test/java/com/spotify/github/v3/checks/AnnotationTest.java
+++ b/src/test/java/com/spotify/github/v3/checks/AnnotationTest.java
@@ -37,6 +37,8 @@ public class AnnotationTest {
          .path("path")
          .startLine(1)
          .endLine(2)
+         .startColumn(1)
+         .endColumn(9)
          .annotationLevel(AnnotationLevel.notice);
    }
 
@@ -78,5 +80,17 @@ public class AnnotationTest {
     String serializedAnnotation = Json.create().toJsonUnchecked(annotationWithEmptyStringFields);
     String expected = "{\"path\":\"\",\"annotation_level\":\"notice\",\"message\":\"\",\"title\":\"\",\"start_line\":1,\"end_line\":2}";
     assertThat(serializedAnnotation, is(expected));
+  }
+
+  @Test
+  public void clearsColumnFieldsForMultiLineAnnotation() {
+    Annotation annotationSpanningMultipleLines = builder().startLine(1).endLine(2).build();
+    String serializedAnnotation = Json.create().toJsonUnchecked(annotationSpanningMultipleLines);
+    String serializedWithoutColumns = "{\"path\":\"path\",\"annotation_level\":\"notice\",\"message\":\"message\",\"title\":\"title\",\"raw_details\":\"rawDetails\",\"start_line\":1,\"end_line\":2";
+    assertThat(serializedAnnotation, is(serializedWithoutColumns + "}"));
+
+    Annotation annotationOnSingleLine = builder().startLine(1).endLine(1).build();
+    serializedAnnotation = Json.create().toJsonUnchecked(annotationOnSingleLine);
+    assertThat(serializedAnnotation, is(serializedWithoutColumns + ",\"start_column\":1,\"end_column\":9}"));
   }
 }


### PR DESCRIPTION
When start_line and end_line have different values & start_column or end_column has value, then Github API throws the following error while creating or updating a Check-run

`HTTP 422: {"resource":"CheckRun","code":"invalid","field":"annotations"}`