### PR TITLE
fix: update parameters passed to create teams client

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/OrganisationClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/OrganisationClient.java
@@ -50,7 +50,7 @@ public class OrganisationClient {
    *
    * @return Teams API client
    */
-  public TeamClient createTeamClient(final GitHubClient github, final String org) {
+  public TeamClient createTeamClient() {
     return TeamClient.create(github, org);
   }
 }

--- a/src/test/java/com/spotify/github/v3/clients/OrganisationClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/OrganisationClientTest.java
@@ -58,7 +58,7 @@ public class OrganisationClientTest {
 
   @Test
   public void testTeamClient() throws Exception {
-    final TeamClient teamClient = organisationClient.createTeamClient(github, "github");
+    final TeamClient teamClient = organisationClient.createTeamClient();
     final CompletableFuture<Team> fixture =
         completedFuture(json.fromJson(getFixture("team_get.json"), Team.class));
     when(github.request("/orgs/github/teams/justice-league", Team.class)).thenReturn(fixture);


### PR DESCRIPTION
### What does this PR do?
Updates functionality to remove parameters incorrectly passed to create teams client. These parameters are instead retrieved from the parent client (Organisation Client).

### How to test?
The tests have been updated to reflect these changes