### PR TITLE
feat: add organisation app installation functionality 

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/GithubAppClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/GithubAppClient.java
@@ -82,8 +82,16 @@ public class GithubAppClient {
    * @return an Installation
    */
   public CompletableFuture<Installation> getInstallation() {
-    return maybeRepo.map(repo-> github.request(
-        String.format(GET_INSTALLATION_REPO_URL, owner, repo), Installation.class, extraHeaders)).orElseGet(this::getOrgInstallation);
+    return maybeRepo.map(this::getRepoInstallation).orElseGet(this::getOrgInstallation);
+  }
+
+  /**
+   * Get an installation of an org
+   * @return an Installation
+   */
+  private CompletableFuture<Installation> getRepoInstallation(final String repo) {
+    return github.request(
+        String.format(GET_INSTALLATION_REPO_URL, owner, repo), Installation.class);
   }
 
   /**

--- a/src/main/java/com/spotify/github/v3/clients/GithubAppClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/GithubAppClient.java
@@ -38,6 +38,11 @@ public class GithubAppClient {
   private static final String GET_INSTALLATIONS_URL = "/app/installations?per_page=100";
   private static final String GET_INSTALLATION_REPO_URL = "/repos/%s/%s/installation";
   private static final String LIST_ACCESSIBLE_REPOS_URL = "/installation/repositories";
+
+  /*
+    Owner and org are interchangeable and therefore "owner" is used to
+    refer to the organisation in the installation endpoint
+  */
   private static final String GET_INSTALLATION_ORG_URL = "/orgs/%s/installation";
 
   private final GitHubClient github;
@@ -72,21 +77,20 @@ public class GithubAppClient {
   }
 
   /**
-   * Get Installation of a repo
+   * Get Installation
    *
-   * @return a list of Installation
+   * @return an Installation
    */
   public CompletableFuture<Installation> getInstallation() {
     return maybeRepo.map(repo-> github.request(
-        String.format(GET_INSTALLATION_REPO_URL, owner, repo), Installation.class, extraHeaders)).orElseGet(() -> getOrgInstallation(owner));
+        String.format(GET_INSTALLATION_REPO_URL, owner, repo), Installation.class, extraHeaders)).orElseGet(this::getOrgInstallation);
   }
 
   /**
    * Get an installation of an org
-   * @param owner the owner/organisation
    * @return an Installation
    */
-  private CompletableFuture<Installation> getOrgInstallation(final String owner) {
+  private CompletableFuture<Installation> getOrgInstallation() {
     return github.request(
         String.format(GET_INSTALLATION_ORG_URL, owner), Installation.class);
   }

--- a/src/main/java/com/spotify/github/v3/clients/GithubAppClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/GithubAppClient.java
@@ -86,7 +86,7 @@ public class GithubAppClient {
   }
 
   /**
-   * Get an installation of an org
+   * Get an installation of a repo
    * @return an Installation
    */
   private CompletableFuture<Installation> getRepoInstallation(final String repo) {

--- a/src/main/java/com/spotify/github/v3/clients/OrganisationClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/OrganisationClient.java
@@ -20,17 +20,7 @@
 //
 package com.spotify.github.v3.clients;
 
-import java.lang.invoke.MethodHandles;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class OrganisationClient {
-
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
-  private static final String TEAM_TEMPLATE = "/orgs/%s/teams";
-
-  private static final String TEAM_SLUG_TEMPLATE = "/orgs/%s/teams/%s";
 
   private final GitHubClient github;
 
@@ -52,5 +42,14 @@ public class OrganisationClient {
    */
   public TeamClient createTeamClient() {
     return TeamClient.create(github, org);
+  }
+
+  /**
+   * Create GitHub App API client
+   *
+   * @return GitHub App API client
+   */
+  public GithubAppClient createGithubAppClient() {
+    return new GithubAppClient(github, org);
   }
 }

--- a/src/test/java/com/spotify/github/v3/clients/OrganisationClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/OrganisationClientTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.io.Resources;
 import com.spotify.github.jackson.Json;
 import com.spotify.github.v3.Team;
+import com.spotify.github.v3.checks.Installation;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import org.junit.Before;
@@ -65,5 +66,16 @@ public class OrganisationClientTest {
     final Team team = teamClient.getTeam("justice-league").get();
     assertThat(team.id(), is(1));
     assertThat(team.name(), is("Justice League"));
+  }
+
+  @Test
+  public void testAppClient() throws Exception {
+    final GithubAppClient githubAppClient = organisationClient.createGithubAppClient();
+    final CompletableFuture<Installation> fixture =
+        completedFuture(json.fromJson(getFixture("../githubapp/installation.json"), Installation.class));
+    when(github.request("/orgs/github/installation", Installation.class)).thenReturn(fixture);
+    final Installation installation = githubAppClient.getInstallation().get();
+    assertThat(installation.id(), is(1));
+    assertThat(installation.account().login(), is("github"));
   }
 }

--- a/src/test/resources/com/spotify/github/v3/githubapp/installation.json
+++ b/src/test/resources/com/spotify/github/v3/githubapp/installation.json
@@ -1,0 +1,34 @@
+{
+  "id": 1,
+  "account": {
+    "login": "github",
+    "id": 1,
+    "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+    "url": "https://api.github.com/orgs/github",
+    "repos_url": "https://api.github.com/orgs/github/repos",
+    "events_url": "https://api.github.com/orgs/github/events",
+    "hooks_url": "https://api.github.com/orgs/github/hooks",
+    "issues_url": "https://api.github.com/orgs/github/issues",
+    "members_url": "https://api.github.com/orgs/github/members{/member}",
+    "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "description": "A great organization"
+  },
+  "access_tokens_url": "https://api.github.com/installations/1/access_tokens",
+  "repositories_url": "https://api.github.com/installation/repositories",
+  "html_url": "https://github.com/organizations/github/settings/installations/1",
+  "app_id": 1,
+  "target_id": 1,
+  "target_type": "Organization",
+  "permissions": {
+    "metadata": "read",
+    "contents": "read",
+    "issues": "write",
+    "single_file": "write"
+  },
+  "events": [
+    "push",
+    "pull_request"
+  ],
+  "single_file_name": "config.yml"
+}


### PR DESCRIPTION
### What does this PR do?
Adds the ability to instantiate the GitHubAppClient from the OrganisationClient
Updates the getInstallation() function to support getting the installations at an organisation level

### How to test?
Unit tests have been updated to reflect these changes