### PR TITLE
bug: add missing conclusion to CheckRunConclusion

### DIFF
--- a/src/main/java/com/spotify/github/v3/checks/CheckRunConclusion.java
+++ b/src/main/java/com/spotify/github/v3/checks/CheckRunConclusion.java
@@ -32,5 +32,6 @@ public enum CheckRunConclusion {
   failure,
   neutral,
   success,
+  skipped,
   stale
 }


### PR DESCRIPTION
**Problem**

Could not deserialize a returned response for a request to the API, due to one of my checks being `skipped`.

This is however a valid conclusion for a check run, as per [current API version]( https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28).

**Solution**

Add the missing value to `CheckRunConclusion` enum.