### PR TITLE
feat: create separate team update request

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/TeamClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/TeamClient.java
@@ -32,6 +32,7 @@ import com.spotify.github.v3.orgs.Membership;
 import com.spotify.github.v3.orgs.TeamInvitation;
 import com.spotify.github.v3.orgs.requests.MembershipCreate;
 import com.spotify.github.v3.orgs.requests.TeamCreate;
+import com.spotify.github.v3.orgs.requests.TeamUpdate;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -107,7 +108,7 @@ public class TeamClient {
    * @param slug slug of the team name
    * @return team
    */
-  public CompletableFuture<Team> updateTeam(final TeamCreate request, final String slug) {
+  public CompletableFuture<Team> updateTeam(final TeamUpdate request, final String slug) {
     final String path = String.format(TEAM_SLUG_TEMPLATE, org, slug);
     log.debug("Updating team in: " + path);
     return github.patch(path, github.json().toJsonUnchecked(request), Team.class);

--- a/src/main/java/com/spotify/github/v3/orgs/requests/TeamUpdate.java
+++ b/src/main/java/com/spotify/github/v3/orgs/requests/TeamUpdate.java
@@ -29,9 +29,9 @@ import org.immutables.value.Value;
 /** Request to create a team within a given organisation */
 @Value.Immutable
 @GithubStyle
-@JsonSerialize(as = ImmutableTeamCreate.class)
-@JsonDeserialize(as = ImmutableTeamCreate.class)
-public interface TeamCreate {
+@JsonSerialize(as = ImmutableTeamUpdate.class)
+@JsonDeserialize(as = ImmutableTeamUpdate.class)
+public interface TeamUpdate {
 
   /** The name of the team. */
   @Nullable
@@ -63,17 +63,6 @@ public interface TeamCreate {
   @SuppressWarnings("checkstyle:methodname")
   Optional<String> notification_setting();
 
-  /**
-   * List GitHub IDs for organization members who will
-   * become team maintainers.
-   */
-  Optional<String> maintainers();
-
-  /** The full name (e.g., "organization-name/repository-name")
-   * of repositories to add the team to.
-   */
-  @SuppressWarnings("checkstyle:methodname")
-  Optional<String> repo_names();
 
   /** The ID of a team to set as the parent team. */
   @SuppressWarnings("checkstyle:methodname")

--- a/src/test/java/com/spotify/github/v3/clients/TeamClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/TeamClientTest.java
@@ -42,6 +42,7 @@ import com.spotify.github.v3.orgs.Membership;
 import com.spotify.github.v3.orgs.TeamInvitation;
 import com.spotify.github.v3.orgs.requests.MembershipCreate;
 import com.spotify.github.v3.orgs.requests.TeamCreate;
+import com.spotify.github.v3.orgs.requests.TeamUpdate;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -127,16 +128,16 @@ public class TeamClientTest {
 
   @Test
   public void updateTeam() throws Exception {
-    final TeamCreate teamCreateRequest =
+    final TeamUpdate teamUpdateRequest =
         json.fromJson(
             getFixture("teams_patch.json"),
-            TeamCreate.class);
+            TeamUpdate.class);
 
     final CompletableFuture<Team> fixtureResponse = completedFuture(json.fromJson(
         getFixture("teams_patch_response.json"),
         Team.class));
     when(github.patch(any(), any(), eq(Team.class))).thenReturn(fixtureResponse);
-    final CompletableFuture<Team> actualResponse = teamClient.updateTeam(teamCreateRequest, "justice-league");
+    final CompletableFuture<Team> actualResponse = teamClient.updateTeam(teamUpdateRequest, "justice-league");
 
     assertThat(actualResponse.get().name(), is("Justice League2"));
   }


### PR DESCRIPTION
### What does this PR do?
Fixes the PATCH teams endpoint so that it has a separate Team Update request with the correct fields that can be modified.

### How to test?
Unit tests