### PR TITLE
feat: add support for creating and updating file contents

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
@@ -42,7 +42,10 @@ import com.spotify.github.v3.repos.Commit;
 import com.spotify.github.v3.repos.CommitComparison;
 import com.spotify.github.v3.repos.CommitItem;
 import com.spotify.github.v3.repos.CommitStatus;
+import com.spotify.github.v3.repos.CommitWithFolderContent;
 import com.spotify.github.v3.repos.Content;
+import com.spotify.github.v3.repos.requests.FileCreate;
+import com.spotify.github.v3.repos.requests.FileUpdate;
 import com.spotify.github.v3.repos.FolderContent;
 import com.spotify.github.v3.repos.Languages;
 import com.spotify.github.v3.repos.Repository;
@@ -445,6 +448,32 @@ public class RepositoryClient {
    */
   public CompletableFuture<Content> getFileContent(final String path, final String ref) {
     return github.request(getContentPath(path, "?ref=" + ref), Content.class);
+  }
+
+  /**
+   * Create a file
+   *
+   * @param path path to a file
+   * @param request file creation request
+   * @return commit with content
+   */
+  public CompletableFuture<CommitWithFolderContent> createFileContent(final String path, final FileCreate request) {
+    final String contentPath = getContentPath(path, "");
+    final String requestBody = github.json().toJsonUnchecked(request);
+    return github.put(contentPath, requestBody, CommitWithFolderContent.class);
+  }
+
+  /**
+   * Update file contents
+   *
+   * @param path path to a file
+   * @param request file update request
+   * @return commit with content
+   */
+  public CompletableFuture<CommitWithFolderContent> updateFileContent(final String path, final FileUpdate request) {
+    final String contentPath = getContentPath(path, "");
+    final String requestBody = github.json().toJsonUnchecked(request);
+    return github.put(contentPath, requestBody, CommitWithFolderContent.class);
   }
 
   /**

--- a/src/main/java/com/spotify/github/v3/repos/CommitWithFolderContent.java
+++ b/src/main/java/com/spotify/github/v3/repos/CommitWithFolderContent.java
@@ -1,0 +1,41 @@
+/*-
+ * -\-\-
+ * github-api
+ * --
+ * Copyright (C) 2016 - 2023 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.github.v3.repos;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.spotify.github.GithubStyle;
+import com.spotify.github.v3.git.Commit;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@GithubStyle
+@JsonSerialize(as = ImmutableCommitWithFolderContent.class)
+@JsonDeserialize(as = ImmutableCommitWithFolderContent.class)
+public interface CommitWithFolderContent {
+
+  /** Repository content resource */
+  FolderContent content();
+
+  /** Commit resource */
+  Commit commit();
+
+}

--- a/src/main/java/com/spotify/github/v3/repos/requests/FileCreate.java
+++ b/src/main/java/com/spotify/github/v3/repos/requests/FileCreate.java
@@ -1,0 +1,49 @@
+/*-
+ * -\-\-
+ * github-api
+ * --
+ * Copyright (C) 2016 - 2023 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.github.v3.repos.requests;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.spotify.github.GithubStyle;
+import org.immutables.value.Value;
+
+import javax.annotation.Nullable;
+
+/**
+ * Request to create a file.
+ */
+@Value.Immutable
+@GithubStyle
+@JsonSerialize(as = ImmutableFileCreate.class)
+@JsonDeserialize(as = ImmutableFileCreate.class)
+public interface FileCreate {
+
+  /** The commit message */
+  String message();
+
+  /** The new file content, using Base64 encoding */
+  String content();
+
+  /** The branch name. Default: the repository’s default branch  */
+  @Nullable
+  String branch();
+
+}

--- a/src/main/java/com/spotify/github/v3/repos/requests/FileUpdate.java
+++ b/src/main/java/com/spotify/github/v3/repos/requests/FileUpdate.java
@@ -1,0 +1,52 @@
+/*-
+ * -\-\-
+ * github-api
+ * --
+ * Copyright (C) 2016 - 2023 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.github.v3.repos.requests;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.spotify.github.GithubStyle;
+import org.immutables.value.Value;
+
+import javax.annotation.Nullable;
+
+/**
+ * Request to update file content.
+ */
+@Value.Immutable
+@GithubStyle
+@JsonSerialize(as = ImmutableFileUpdate.class)
+@JsonDeserialize(as = ImmutableFileUpdate.class)
+public interface FileUpdate {
+
+  /** The commit message */
+  String message();
+
+  /** The new file content, using Base64 encoding */
+  String content();
+
+  /** The SHA of the file being replaced. */
+  String sha();
+
+  /** The branch name. Default: the repository’s default branch  */
+  @Nullable
+  String branch();
+
+}

--- a/src/test/resources/com/spotify/github/v3/repos/create-content-repsonse.json
+++ b/src/test/resources/com/spotify/github/v3/repos/create-content-repsonse.json
@@ -1,0 +1,52 @@
+{
+  "content": {
+    "name": "README.md",
+    "path": "test/README.md",
+    "sha": "95b966ae1c166bd92f8ae7d1c313e738c731dfc3",
+    "size": 9,
+    "url": "https://api.github.com/repos/someowner/somerepo/contents/test/README.md",
+    "html_url": "https://github.com/someowner/somerepo/blob/master/test/README.md",
+    "git_url": "https://api.github.com/repos/someowner/somerepo/git/blobs/95b966ae1c166bd92f8ae7d1c313e738c731dfc3",
+    "download_url": "https://raw.githubusercontent.com/someowner/HelloWorld/master/test/README.md",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/someowner/somerepo/contents/test/README.md",
+      "git": "https://api.github.com/repos/someowner/somerepo/git/blobs/95b966ae1c166bd92f8ae7d1c313e738c731dfc3",
+      "html": "https://github.com/someowner/somerepo/blob/master/test/README.md"
+    }
+  },
+  "commit": {
+    "sha": "7638417db6d59f3c431d3e1f261cc637155684cd",
+    "node_id": "MDY6Q29tbWl0NzYzODQxN2RiNmQ1OWYzYzQzMWQzZTFmMjYxY2M2MzcxNTU2ODRjZA==",
+    "url": "https://api.github.com/repos/someowner/somerepo/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd",
+    "html_url": "https://github.com/someowner/somerepo/git/commit/7638417db6d59f3c431d3e1f261cc637155684cd",
+    "author": {
+      "date": "2014-11-07T22:01:45Z",
+      "name": "Monalisa Octocat",
+      "email": "octocat@github.com"
+    },
+    "committer": {
+      "date": "2014-11-07T22:01:45Z",
+      "name": "Monalisa Octocat",
+      "email": "octocat@github.com"
+    },
+    "message": "my commit message",
+    "tree": {
+      "url": "https://api.github.com/repos/someowner/somerepo/git/trees/691272480426f78a0138979dd3ce63b77f706feb",
+      "sha": "691272480426f78a0138979dd3ce63b77f706feb"
+    },
+    "parents": [
+      {
+        "url": "https://api.github.com/repos/someowner/somerepo/git/commits/1acc419d4d6a9ce985db7be48c6349a0475975b5",
+        "html_url": "https://github.com/someowner/somerepo/git/commit/1acc419d4d6a9ce985db7be48c6349a0475975b5",
+        "sha": "1acc419d4d6a9ce985db7be48c6349a0475975b5"
+      }
+    ],
+    "verification": {
+      "verified": false,
+      "reason": "unsigned",
+      "signature": null,
+      "payload": null
+    }
+  }
+}

--- a/src/test/resources/com/spotify/github/v3/repos/create-content-request.json
+++ b/src/test/resources/com/spotify/github/v3/repos/create-content-request.json
@@ -1,0 +1,4 @@
+{
+  "message": "my commit message",
+  "content": "encoded content ..."
+}

--- a/src/test/resources/com/spotify/github/v3/repos/update-content-repsonse.json
+++ b/src/test/resources/com/spotify/github/v3/repos/update-content-repsonse.json
@@ -1,0 +1,52 @@
+{
+  "content": {
+    "name": "README.md",
+    "path": "test/README.md",
+    "sha": "95b966ae1c166bd92f8ae7d1c313e738c731dfc3",
+    "size": 9,
+    "url": "https://api.github.com/repos/someowner/somerepo/contents/test/README.md",
+    "html_url": "https://github.com/someowner/somerepo/blob/master/test/README.md",
+    "git_url": "https://api.github.com/repos/someowner/somerepo/git/blobs/95b966ae1c166bd92f8ae7d1c313e738c731dfc3",
+    "download_url": "https://raw.githubusercontent.com/someowner/HelloWorld/master/test/README.md",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/someowner/somerepo/contents/test/README.md",
+      "git": "https://api.github.com/repos/someowner/somerepo/git/blobs/95b966ae1c166bd92f8ae7d1c313e738c731dfc3",
+      "html": "https://github.com/someowner/somerepo/blob/master/test/README.md"
+    }
+  },
+  "commit": {
+    "sha": "7638417db6d59f3c431d3e1f261cc637155684cd",
+    "node_id": "MDY6Q29tbWl0NzYzODQxN2RiNmQ1OWYzYzQzMWQzZTFmMjYxY2M2MzcxNTU2ODRjZA==",
+    "url": "https://api.github.com/repos/someowner/somerepo/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd",
+    "html_url": "https://github.com/someowner/somerepo/git/commit/7638417db6d59f3c431d3e1f261cc637155684cd",
+    "author": {
+      "date": "2014-11-07T22:01:45Z",
+      "name": "Monalisa Octocat",
+      "email": "octocat@github.com"
+    },
+    "committer": {
+      "date": "2014-11-07T22:01:45Z",
+      "name": "Monalisa Octocat",
+      "email": "octocat@github.com"
+    },
+    "message": "my commit message",
+    "tree": {
+      "url": "https://api.github.com/repos/someowner/somerepo/git/trees/691272480426f78a0138979dd3ce63b77f706feb",
+      "sha": "691272480426f78a0138979dd3ce63b77f706feb"
+    },
+    "parents": [
+      {
+        "url": "https://api.github.com/repos/someowner/somerepo/git/commits/1acc419d4d6a9ce985db7be48c6349a0475975b5",
+        "html_url": "https://github.com/someowner/somerepo/git/commit/1acc419d4d6a9ce985db7be48c6349a0475975b5",
+        "sha": "1acc419d4d6a9ce985db7be48c6349a0475975b5"
+      }
+    ],
+    "verification": {
+      "verified": false,
+      "reason": "unsigned",
+      "signature": null,
+      "payload": null
+    }
+  }
+}

--- a/src/test/resources/com/spotify/github/v3/repos/update-content-request.json
+++ b/src/test/resources/com/spotify/github/v3/repos/update-content-request.json
@@ -1,0 +1,6 @@
+{
+  "message": "my commit message",
+  "content": "encoded content ...",
+  "sha": "12345",
+  "branch": "test-branch"
+}


### PR DESCRIPTION
See https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#create-or-update-file-contents.

I applied the well known engineering principle of "monkey-see-monkey-do". Hopefully my grasp of how to do things in this project is not off too much. Checkstyle yelling at me was definitely helpful.

Happy to do smaller follow-ups :)