### PR TITLE
feat: add diff method PullRequestClient

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/PullRequestClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/PullRequestClient.java
@@ -248,6 +248,22 @@ public class PullRequestClient {
         });
   }
 
+  public CompletableFuture<Reader> diff(final int number) {
+    final String path = String.format(PR_NUMBER_TEMPLATE, owner, repo, number);
+    final Map<String, String> extraHeaders = ImmutableMap.of(
+        HttpHeaders.ACCEPT, "application/vnd.github.diff"
+    );
+    log.debug("Fetching pull diff from " + path);
+    return github.request(path, extraHeaders)
+        .thenApply(response -> {
+          final var body = response.body();
+          if (isNull(body)) {
+            return Reader.nullReader();
+          }
+          return body.charStream();
+        });
+  }
+
   private CompletableFuture<List<PullRequestItem>> list(final String parameterPath) {
     final String path = String.format(PR_TEMPLATE + parameterPath, owner, repo);
     log.debug("Fetching pull requests from " + path);

--- a/src/test/java/com/spotify/github/v3/clients/PullRequestClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/PullRequestClientTest.java
@@ -319,12 +319,12 @@ public class PullRequestClientTest {
         PullRequestClient.create(github, "owner", "repo");
 
     final CompletableFuture<Reader> result =
-        pullRequestClient.patch(1);
+        pullRequestClient.diff(1);
 
     capture.getValue().onResponse(call, response);
 
-    Reader patchReader = result.get();
+    Reader diffReader = result.get();
 
-    assertEquals(getFixture("diff.txt"), IOUtils.toString(patchReader));
+    assertEquals(getFixture("diff.txt"), IOUtils.toString(diffReader));
   }
 }

--- a/src/test/resources/com/spotify/github/v3/clients/diff.txt
+++ b/src/test/resources/com/spotify/github/v3/clients/diff.txt
@@ -1,0 +1,9 @@
+diff --git a/filename b/filename
+index 01a9f34..500bb03 100644
+--- a/nf
++++ b/nf
+@@ -1,3 +1,4 @@
+ asdf
++asdf
+--
+2.39.0


### PR DESCRIPTION
Currently there is no support for getting the diff for a pullrequest. This is done by [passing a certain header](https://docs.github.com/en/rest/overview/media-types?apiVersion=2022-11-28#diff-media-type-for-commits-commit-comparison-and-pull-requests) (`application/vnd.github.diff`) which is done in this PR