### PR TITLE
Add support to get Installation identified by its installation id

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/GithubAppClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/GithubAppClient.java
@@ -34,7 +34,7 @@ import javax.ws.rs.core.HttpHeaders;
 /** Apps API client */
 public class GithubAppClient {
 
-  private static final String GET_INSTALLATION_URL = "/app/installations/%s";
+  private static final String GET_INSTALLATION_BY_ID_URL = "/app/installations/%s";
   private static final String GET_ACCESS_TOKEN_URL = "/app/installations/%s/access_tokens";
   private static final String GET_INSTALLATIONS_URL = "/app/installations?per_page=100";
   private static final String GET_INSTALLATION_REPO_URL = "/repos/%s/%s/installation";
@@ -93,7 +93,7 @@ public class GithubAppClient {
    */
   public CompletableFuture<Installation> getInstallation(final Integer installationId) {
     return github.request(
-        String.format(GET_INSTALLATION_URL, installationId), Installation.class);
+        String.format(GET_INSTALLATION_BY_ID_URL, installationId), Installation.class);
   }
 
   /**

--- a/src/main/java/com/spotify/github/v3/clients/GithubAppClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/GithubAppClient.java
@@ -34,6 +34,7 @@ import javax.ws.rs.core.HttpHeaders;
 /** Apps API client */
 public class GithubAppClient {
 
+  private static final String GET_INSTALLATION_URL = "/app/installations/%s";
   private static final String GET_ACCESS_TOKEN_URL = "/app/installations/%s/access_tokens";
   private static final String GET_INSTALLATIONS_URL = "/app/installations?per_page=100";
   private static final String GET_INSTALLATION_REPO_URL = "/repos/%s/%s/installation";
@@ -83,6 +84,16 @@ public class GithubAppClient {
    */
   public CompletableFuture<Installation> getInstallation() {
     return maybeRepo.map(this::getRepoInstallation).orElseGet(this::getOrgInstallation);
+  }
+
+  /**
+   * Get Installation identified by its installation id
+   *
+   * @return an Installation
+   */
+  public CompletableFuture<Installation> getInstallation(final Integer installationId) {
+    return github.request(
+        String.format(GET_INSTALLATION_URL, installationId), Installation.class);
   }
 
   /**

--- a/src/test/java/com/spotify/github/v3/clients/GithubAppClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/GithubAppClientTest.java
@@ -144,4 +144,20 @@ public class GithubAppClientTest {
     RecordedRequest recordedRequest = mockServer.takeRequest(1, TimeUnit.MILLISECONDS);
     assertThat(recordedRequest.getRequestUrl().encodedPath(), is("/repos/owner/repo/installation"));
   }
+
+  @Test
+  public void getInstallationByInstallationId() throws Exception {
+    mockServer.enqueue(
+        new MockResponse()
+            .setResponseCode(200)
+            .setBody(FixtureHelper.loadFixture("githubapp/installation.json")));
+
+    Installation installation = client.getInstallation(1234).join();
+
+    assertThat(installation.id(), is(1));
+    assertThat(installation.account().login(), is("github"));
+
+    RecordedRequest recordedRequest = mockServer.takeRequest(1, TimeUnit.MILLISECONDS);
+    assertThat(recordedRequest.getRequestUrl().encodedPath(), is("/app/installations/1234"));
+  }
 }


### PR DESCRIPTION
Hi, this PR adds support to get the an installation's information using the installation id. Essentially, it enables to use the `/app/installations/{installation_id}` [API endpoint](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-installation-for-the-authenticated-app).

