### PR TITLE
Support to download repository content (zip/tar)

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
@@ -251,7 +251,7 @@ public class RepositoryClient {
    * @return a CompletableFuture that resolves to an Optional InputStream
    */
   public CompletableFuture<Optional<InputStream>> downloadTarball() {
-    return downloadTarball(null);
+    return downloadRepository(REPOSITORY_DOWNLOAD_TARBALL, Optional.empty());
   }
 
   /**
@@ -260,7 +260,7 @@ public class RepositoryClient {
    * @return a CompletableFuture that resolves to an Optional InputStream
    */
   public CompletableFuture<Optional<InputStream>> downloadTarball(final String ref) {
-    return downloadRepository(REPOSITORY_DOWNLOAD_TARBALL, ref);
+    return downloadRepository(REPOSITORY_DOWNLOAD_TARBALL, Optional.of(ref));
   }
 
   /**
@@ -269,7 +269,7 @@ public class RepositoryClient {
    * @return a CompletableFuture that resolves to an Optional InputStream
    */
   public CompletableFuture<Optional<InputStream>> downloadZipball() {
-    return downloadZipball(null);
+    return downloadRepository(REPOSITORY_DOWNLOAD_ZIPBALL, Optional.empty());
   }
 
   /**
@@ -278,11 +278,11 @@ public class RepositoryClient {
    * @return a CompletableFuture that resolves to an Optional InputStream
    */
   public CompletableFuture<Optional<InputStream>> downloadZipball(final String ref) {
-    return downloadRepository(REPOSITORY_DOWNLOAD_ZIPBALL, ref);
+    return downloadRepository(REPOSITORY_DOWNLOAD_ZIPBALL, Optional.of(ref));
   }
 
-  private CompletableFuture<Optional<InputStream>> downloadRepository(final String path, final String ref) {
-    final var repoRef = Strings.nullToEmpty(ref);
+  private CompletableFuture<Optional<InputStream>> downloadRepository(final String path, final Optional<String> maybeRef) {
+    final var repoRef = maybeRef.orElse("");
     final var repoPath = String.format(path, owner, repo, repoRef);
     return github.request(repoPath).thenApply(response -> {
       var body = response.body();

--- a/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
@@ -50,6 +50,7 @@ import com.spotify.github.v3.repos.RepositoryInvitation;
 import com.spotify.github.v3.repos.Status;
 import com.spotify.github.v3.repos.requests.AuthenticatedUserRepositoriesFilter;
 import com.spotify.github.v3.repos.requests.RepositoryCreateStatus;
+import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
 import java.util.Iterator;
 import java.util.List;
@@ -91,6 +92,8 @@ public class RepositoryClient {
   private static final String REPOSITORY_COLLABORATOR = "/repos/%s/%s/collaborators/%s";
   private static final String REPOSITORY_INVITATION = "/repos/%s/%s/invitations/%s";
   private static final String REPOSITORY_INVITATIONS = "/repos/%s/%s/invitations";
+  private static final String REPOSITORY_DOWNLOAD_TARBALL = "/repos/%s/%s/tarball/%s";
+  private static final String REPOSITORY_DOWNLOAD_ZIPBALL = "/repos/%s/%s/zipball/%s";
   private final String owner;
   private final String repo;
   private final GitHubClient github;
@@ -240,6 +243,56 @@ public class RepositoryClient {
   public CompletableFuture<List<RepositoryInvitation>> listInvitations() {
     final String path = String.format(REPOSITORY_INVITATIONS, owner, repo);
     return github.request(path, LIST_REPOSITORY_INVITATION);
+  }
+
+  /**
+   * Downloads a tar archive of the repository’s default branch (usually main).
+   *
+   * @return a CompletableFuture that resolves to an Optional InputStream
+   */
+  public CompletableFuture<Optional<InputStream>> downloadTarball() {
+    return downloadTarball(null);
+  }
+
+  /**
+   * Downloads a tar archive of the repository. Use :ref to specify a branch or tag to download.
+   *
+   * @return a CompletableFuture that resolves to an Optional InputStream
+   */
+  public CompletableFuture<Optional<InputStream>> downloadTarball(final String ref) {
+    return downloadRepository(REPOSITORY_DOWNLOAD_TARBALL, ref);
+  }
+
+  /**
+   * Downloads a zip archive of the repository’s default branch (usually main).
+   *
+   * @return a CompletableFuture that resolves to an Optional InputStream
+   */
+  public CompletableFuture<Optional<InputStream>> downloadZipball() {
+    return downloadZipball(null);
+  }
+
+  /**
+   * Downloads a zip archive of the repository. Use :ref to specify a branch or tag to download.
+   *
+   * @return a CompletableFuture that resolves to an Optional InputStream
+   */
+  public CompletableFuture<Optional<InputStream>> downloadZipball(final String ref) {
+    return downloadRepository(REPOSITORY_DOWNLOAD_ZIPBALL, ref);
+  }
+
+  private CompletableFuture<Optional<InputStream>> downloadRepository(final String path, final String ref) {
+    final var repoRef = Strings.nullToEmpty(ref);
+    final var repoPath = String.format(path, owner, repo, repoRef);
+    return github.request(repoPath).thenApply(response -> {
+      var body = response.body();
+
+      if (body == null) {
+        return Optional.empty();
+      }
+
+      return Optional.of(body.byteStream());
+    });
   }
 
   /**


### PR DESCRIPTION
Hi, this PR adds support to download the repository content as [zip](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#download-a-repository-archive-zip) or [tar](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#download-a-repository-archive-tar) archive.

I extended the Repository client with two separate methods to download the tar or zip archive. The methods return an Optional InputStream that can be consumed accordingly, e.g., by a `BufferedInputStream` that writes it read bytes to a `FileOutputStream` or by following this [guide](https://www.baeldung.com/convert-input-stream-to-a-file).