### PR TITLE
chore: update GH Actions workflows

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -4,9 +4,8 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '*.md'
-      - '.gitignore'
+# Do not execute only for specific paths if workflow is required.
+# https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
 
 jobs:
   build:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,29 +1,37 @@
-# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
-# For more information see: https://github.com/actions/setup-java#apache-maven-with-a-settings-path
-
 name: maven-build
 
 on:
-    pull_request:
-      branches:
-        - master
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '*.md'
+      - '.gitignore'
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.11
-        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-        settings-path: ${{ github.workspace }} # location for the settings.xml file
 
-    - name: Build
-      run: mvn -B package --file pom.xml -Pcoverage -Dsytle.colors=always --errors
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: corretto
+          cache: maven
+
+      - name: Build with Maven
+        run: >
+          mvn
+          --batch-mode
+          --file pom.xml
+          -Pcoverage
+          -Dsytle.colors=always
+          --errors
+          package
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,42 +1,45 @@
-# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
-# For more information see: https://github.com/actions/setup-java#apache-maven-with-a-settings-path
-
 name: maven-release
 
 on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
+      - '.gitignore'
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.11
-        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-        settings-path: ${{ github.workspace }} # location for the settings.xml file
 
-    - name: Publish
-      uses: samuelmeuli/action-maven-publish@v1
-      with:
-        gpg_private_key: ${{ secrets.gpg_private_key }}
-        gpg_passphrase: ${{ secrets.gpg_passphrase }}
-        nexus_username: ${{ secrets.nexus_username }}
-        nexus_password: ${{ secrets.nexus_password }}
-        maven_args: '-Pcoverage'
+      - uses: actions/checkout@v4
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-#    - name: Release
-#      uses: softprops/action-gh-release@v1
-#      if: startsWith(github.ref, 'refs/tags/')
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: corretto
+          cache: maven
+          server-id: ossrh # Value of distributionManagement.repository.id field of pom.xml
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          settings-path: ${{ github.workspace }} # Location for settings.xml file
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+
+      - name: Publish with Maven deploy
+        run: >
+          mvn
+          --batch-mode
+          --activate-profiles deploy
+          -Pcoverage
+          clean deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This PR is meant to upgrade the different GH Actions workflows to use new versions of existing actions and use new functionalities of these actions.

Changes other than formatting:
* Update `actions/checkout` to version `4`
* Update `actions/setup-java` to version `3`
* Use cache for Maven
* User Amazon Corretto JDK distribution
* Ignore being triggered by changes in `.gitignore` and `*.md` files
* Remove usage of already archived `samuelmeuli/action-maven-publish@v1`
* Perform same action as `samuelmeuli/action-maven-publish@v1` by adding necessary release credentials to `actions/setup-java@v3` and calling `mvn deploy` manually

I tested the changed workflow triggered by `pull_request` locally. Due to the needed secrets for the `push` workflow, I could not test the releasing properly.