### PR TITLE
chore: migrate to Junit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,15 +93,15 @@
         <guava.version>32.1.3-jre</guava.version>
         <jsr305.version>3.0.2</jsr305.version>
         <jsr311-api.version>1.1.1</jsr311-api.version>
-        <junit.version>4.13.1</junit.version>
+        <junit.version>5.10.0</junit.version>
         <slf4j-api.version>1.7.36</slf4j-api.version>
-        <mockito-core.version>3.2.4</mockito-core.version>
+        <mockito-core.version>5.6.0</mockito-core.version>
         <commons-io.version>2.6</commons-io.version>
         <jackson.version>2.15.3</jackson.version>
         <immutables.version>2.9.3</immutables.version>
-        <powermock.version>2.0.2</powermock.version>
-        <objenesis.version>3.0.1</objenesis.version>
+        <objenesis.version>3.3</objenesis.version>
         <opencensus.version>0.31.1</opencensus.version>
+        <okhttp.version>4.11.0</okhttp.version>
 
         <shade.id>${project.groupId}.githubclient.shade</shade.id>
     </properties>
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.14.7</version>
+            <version>${okhttp.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -210,17 +210,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.5.0</version>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -242,32 +243,8 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
-            <version>3.14.7</version>
+            <version>${okhttp.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.mockito</groupId>
-                    <artifactId>mockito-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.mockito</groupId>
-                    <artifactId>mockito-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -409,7 +386,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.2.1</version>
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/src/test/java/com/spotify/github/GitHubInstantTest.java
+++ b/src/test/java/com/spotify/github/GitHubInstantTest.java
@@ -25,7 +25,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.Instant;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GitHubInstantTest {
 

--- a/src/test/java/com/spotify/github/hooks/PullRequestEventTest.java
+++ b/src/test/java/com/spotify/github/hooks/PullRequestEventTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.core.Is.is;
 import com.spotify.github.jackson.Json;
 import com.spotify.github.v3.activity.events.PullRequestEvent;
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PullRequestEventTest {
 

--- a/src/test/java/com/spotify/github/http/LinkTest.java
+++ b/src/test/java/com/spotify/github/http/LinkTest.java
@@ -26,7 +26,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LinkTest {
 

--- a/src/test/java/com/spotify/github/jackson/GitHubInstantModuleTest.java
+++ b/src/test/java/com/spotify/github/jackson/GitHubInstantModuleTest.java
@@ -26,14 +26,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import com.spotify.github.GitHubInstant;
 import java.io.IOException;
 import java.time.Instant;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class GitHubInstantModuleTest {
 
   private Json mapper;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     mapper = Json.create();
   }

--- a/src/test/java/com/spotify/github/opencensus/OpenCensusSpanTest.java
+++ b/src/test/java/com/spotify/github/opencensus/OpenCensusSpanTest.java
@@ -26,7 +26,6 @@ import io.opencensus.trace.AttributeValue;
 import io.opencensus.trace.Status;
 import org.junit.jupiter.api.Test;
 
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/com/spotify/github/opencensus/OpenCensusTracerTest.java
+++ b/src/test/java/com/spotify/github/opencensus/OpenCensusTracerTest.java
@@ -28,11 +28,9 @@ import io.opencensus.trace.config.TraceParams;
 import io.opencensus.trace.export.SpanData;
 import io.opencensus.trace.samplers.Samplers;
 import io.opencensus.trace.unsafe.ContextUtils;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
@@ -115,13 +113,13 @@ public class OpenCensusTracerTest {
         return spans.stream().filter(s -> s.getName().equals(name)).findFirst().get();
     }
 
-    @Before
+    @BeforeEach
     public void setUpExporter() {
         spanExporterHandler = new TestExportHandler();
         Tracing.getExportComponent().getSpanExporter().registerHandler("test", spanExporterHandler);
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setupTracing() {
         final TraceConfig traceConfig = Tracing.getTraceConfig();
         final Sampler sampler = Samplers.alwaysSample();

--- a/src/test/java/com/spotify/github/v3/TeamTest.java
+++ b/src/test/java/com/spotify/github/v3/TeamTest.java
@@ -29,9 +29,8 @@ import com.google.common.io.Resources;
 import com.spotify.github.jackson.Json;
 import java.io.IOException;
 import java.net.URI;
-import java.util.Optional;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TeamTest {
 
@@ -50,7 +49,7 @@ public class TeamTest {
     assertThat(team.repositoriesUrl(), is(URI.create(team.url() + "/repos")));
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     fixture = Resources.toString(getResource(this.getClass(), "team.json"), defaultCharset());
   }

--- a/src/test/java/com/spotify/github/v3/TreeItemTest.java
+++ b/src/test/java/com/spotify/github/v3/TreeItemTest.java
@@ -29,8 +29,8 @@ import com.google.common.io.Resources;
 import com.spotify.github.jackson.Json;
 import com.spotify.github.v3.git.TreeItem;
 import java.io.IOException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TreeItemTest {
 
@@ -42,7 +42,7 @@ public class TreeItemTest {
     assertThat(treeItem.size(), is(12L));
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     fixture = Resources.toString(getResource(this.getClass(), "treeItem.json"), defaultCharset());
   }

--- a/src/test/java/com/spotify/github/v3/UserTest.java
+++ b/src/test/java/com/spotify/github/v3/UserTest.java
@@ -30,8 +30,8 @@ import com.spotify.github.jackson.Json;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class UserTest {
 
@@ -50,7 +50,7 @@ public class UserTest {
     assertThat(user.siteAdmin().get(), is(false));
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     fixture = Resources.toString(getResource(this.getClass(), "user.json"), defaultCharset());
   }

--- a/src/test/java/com/spotify/github/v3/activity/events/CheckRunEventTest.java
+++ b/src/test/java/com/spotify/github/v3/activity/events/CheckRunEventTest.java
@@ -29,8 +29,7 @@ import com.google.common.io.Resources;
 import com.spotify.github.jackson.Json;
 
 import java.io.IOException;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CheckRunEventTest {
 

--- a/src/test/java/com/spotify/github/v3/activity/events/PullRequestEventTest.java
+++ b/src/test/java/com/spotify/github/v3/activity/events/PullRequestEventTest.java
@@ -29,7 +29,7 @@ import com.google.common.io.Resources;
 import com.spotify.github.jackson.Json;
 import com.spotify.github.v3.prs.PullRequestActionState;
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PullRequestEventTest {
 

--- a/src/test/java/com/spotify/github/v3/activity/events/PullRequestReviewEventTest.java
+++ b/src/test/java/com/spotify/github/v3/activity/events/PullRequestReviewEventTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.core.Is.is;
 import com.google.common.io.Resources;
 import com.spotify.github.jackson.Json;
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PullRequestReviewEventTest {
   @Test

--- a/src/test/java/com/spotify/github/v3/activity/events/StatusEventTest.java
+++ b/src/test/java/com/spotify/github/v3/activity/events/StatusEventTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.core.Is.is;
 import com.google.common.io.Resources;
 import com.spotify.github.jackson.Json;
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StatusEventTest {
   @Test

--- a/src/test/java/com/spotify/github/v3/checks/AccessTokenTest.java
+++ b/src/test/java/com/spotify/github/v3/checks/AccessTokenTest.java
@@ -27,7 +27,7 @@ import com.spotify.github.FixtureHelper;
 import com.spotify.github.jackson.Json;
 import java.io.IOException;
 import java.time.ZonedDateTime;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AccessTokenTest {
   private final Json json = Json.create();

--- a/src/test/java/com/spotify/github/v3/checks/AnnotationTest.java
+++ b/src/test/java/com/spotify/github/v3/checks/AnnotationTest.java
@@ -22,14 +22,14 @@ package com.spotify.github.v3.checks;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.spotify.github.jackson.Json;
 import com.spotify.github.v3.checks.ImmutableAnnotation.Builder;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class AnnotationTest {
    private Builder builder() {
@@ -88,16 +88,16 @@ public class AnnotationTest {
   @Test
   public void clearsColumnFieldsForMultiLineAnnotation() {
     Annotation multiLineAnnotation = builder().startLine(1).endLine(2).build();
-    assertTrue(multiLineAnnotation.startColumn().isEmpty());
-    assertTrue(multiLineAnnotation.endColumn().isEmpty());
+    Assertions.assertTrue(multiLineAnnotation.startColumn().isEmpty());
+    Assertions.assertTrue(multiLineAnnotation.endColumn().isEmpty());
 
     Annotation anotherMultiLineAnnotation = builder().startLine(1).endLine(2).startColumn(Optional.empty()).endColumn(1).build();
-    assertTrue(anotherMultiLineAnnotation.startColumn().isEmpty());
-    assertTrue(anotherMultiLineAnnotation.endColumn().isEmpty());
+    Assertions.assertTrue(anotherMultiLineAnnotation.startColumn().isEmpty());
+    Assertions.assertTrue(anotherMultiLineAnnotation.endColumn().isEmpty());
 
     Annotation yetAnotherMultiLineAnnotation = builder().startLine(1).endLine(2).startColumn(1).endColumn(Optional.empty()).build();
-    assertTrue(yetAnotherMultiLineAnnotation.startColumn().isEmpty());
-    assertTrue(yetAnotherMultiLineAnnotation.endColumn().isEmpty());
+    Assertions.assertTrue(yetAnotherMultiLineAnnotation.startColumn().isEmpty());
+    Assertions.assertTrue(yetAnotherMultiLineAnnotation.endColumn().isEmpty());
 
     Annotation singleLineAnnotation = builder().startLine(1).endLine(1).build();
     assertEquals(1, singleLineAnnotation.startColumn().orElse(0));

--- a/src/test/java/com/spotify/github/v3/checks/CheckRunActionTest.java
+++ b/src/test/java/com/spotify/github/v3/checks/CheckRunActionTest.java
@@ -23,7 +23,7 @@ package com.spotify.github.v3.checks;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.spotify.github.v3.checks.ImmutableCheckRunAction.Builder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CheckRunActionTest {
   private Builder builder() {

--- a/src/test/java/com/spotify/github/v3/checks/CheckRunOutputTest.java
+++ b/src/test/java/com/spotify/github/v3/checks/CheckRunOutputTest.java
@@ -23,7 +23,7 @@ package com.spotify.github.v3.checks;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.spotify.github.v3.checks.ImmutableCheckRunOutput.Builder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CheckRunOutputTest {
 

--- a/src/test/java/com/spotify/github/v3/checks/CheckSuiteTest.java
+++ b/src/test/java/com/spotify/github/v3/checks/CheckSuiteTest.java
@@ -39,7 +39,7 @@ public class CheckSuiteTest {
         Resources.toString(
             getResource(this.getClass(), "check-suites-response.json"), defaultCharset());
     final CheckSuiteResponseList checkSuiteResponseList = Json.create().fromJson(fixture, CheckSuiteResponseList.class);
-    assertThat(checkSuiteResponseList.checkSuites().get(0).id(), is(5));
+    assertThat(checkSuiteResponseList.checkSuites().get(0).id(), is(5L));
     assertThat(checkSuiteResponseList.checkSuites().get(0).app().get().slug().get(), is("octoapp"));
   }
 

--- a/src/test/java/com/spotify/github/v3/clients/ChecksClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/ChecksClientTest.java
@@ -43,8 +43,8 @@ import com.spotify.github.v3.checks.ImmutableCheckRunRequest;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.concurrent.CompletableFuture;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ChecksClientTest {
 
@@ -61,7 +61,7 @@ public class ChecksClientTest {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     github = mock(GitHubClient.class);
     checksClient = new ChecksClient(github, "someowner", "somerepo");

--- a/src/test/java/com/spotify/github/v3/clients/GitDataClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/GitDataClientTest.java
@@ -50,8 +50,8 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class GitDataClientTest {
 
@@ -63,7 +63,7 @@ public class GitDataClientTest {
     return Resources.toString(getResource(GitDataClientTest.class, resource), defaultCharset());
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     github = mock(GitHubClient.class);
     gitDataClient = new GitDataClient(github, "someowner", "somerepo");

--- a/src/test/java/com/spotify/github/v3/clients/GitHubAuthTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/GitHubAuthTest.java
@@ -22,12 +22,11 @@ package com.spotify.github.v3.clients;
 
 import static com.spotify.github.v3.clients.ChecksClientTest.loadResource;
 import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.spotify.github.jackson.Json;
@@ -44,9 +43,9 @@ import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class GitHubAuthTest {
 
@@ -82,7 +81,7 @@ public class GitHubAuthTest {
 
   public GitHubAuthTest() throws JsonProcessingException {}
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     client =
         new OkHttpClient.Builder()
@@ -98,7 +97,7 @@ public class GitHubAuthTest {
             .createChecksApiClient();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     mockServer.shutdown();
   }
@@ -261,10 +260,12 @@ public class GitHubAuthTest {
     assertThat(request.getMethod(), is("GET"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void assertNoTokenThrowsException() {
     final GitHubClient apiWithNoKey = GitHubClient.create(URI.create("someurl"), "a-token");
-    apiWithNoKey.createRepositoryClient("foo", "bar").createChecksApiClient();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> apiWithNoKey.createRepositoryClient("foo", "bar").createChecksApiClient());
   }
 
   private AccessToken getTestInstallationToken() {

--- a/src/test/java/com/spotify/github/v3/clients/GithubAppClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/GithubAppClientTest.java
@@ -22,11 +22,9 @@ package com.spotify.github.v3.clients;
 
 import static com.google.common.io.Resources.getResource;
 import static java.nio.charset.Charset.defaultCharset;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
@@ -38,18 +36,15 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class GithubAppClientTest {
 
-  @Rule
   public final MockWebServer mockServer = new MockWebServer();
 
   private final ObjectMapper objectMapper = new ObjectMapper();
@@ -60,7 +55,7 @@ public class GithubAppClientTest {
     return Resources.toString(getResource(GithubAppClientTest.class, resource), defaultCharset());
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     URI uri = mockServer.url("").uri();
     File key = FixtureHelper.loadFile("githubapp/key.pem");

--- a/src/test/java/com/spotify/github/v3/clients/IssueClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/IssueClientTest.java
@@ -33,8 +33,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mock;
 
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
@@ -43,23 +43,16 @@ import com.spotify.github.jackson.Json;
 import com.spotify.github.v3.comment.Comment;
 import java.io.IOException;
 import java.util.List;
-import okhttp3.Headers;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Headers.class, ResponseBody.class, Response.class})
 public class IssueClientTest {
 
   private GitHubClient github;
   private IssueClient issueClient;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     github = mock(GitHubClient.class);
     when(github.json()).thenReturn(Json.create());

--- a/src/test/java/com/spotify/github/v3/clients/JwtTokenIssuerTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/JwtTokenIssuerTest.java
@@ -26,7 +26,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.io.Resources;
 import java.net.URL;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JwtTokenIssuerTest {
 

--- a/src/test/java/com/spotify/github/v3/clients/MockHelper.java
+++ b/src/test/java/com/spotify/github/v3/clients/MockHelper.java
@@ -20,8 +20,8 @@
 
 package com.spotify.github.v3.clients;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mock;
 
 import java.io.IOException;
 import okhttp3.Headers;

--- a/src/test/java/com/spotify/github/v3/clients/OrganisationClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/OrganisationClientTest.java
@@ -38,8 +38,8 @@ import com.spotify.github.v3.orgs.OrgMembership;
 import com.spotify.github.v3.orgs.requests.OrgMembershipCreate;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class OrganisationClientTest {
 
@@ -53,7 +53,7 @@ public class OrganisationClientTest {
     return Resources.toString(getResource(TeamClientTest.class, resource), defaultCharset());
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     github = mock(GitHubClient.class);
     organisationClient = new OrganisationClient(github, "github");

--- a/src/test/java/com/spotify/github/v3/clients/PullRequestClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/PullRequestClientTest.java
@@ -20,24 +20,20 @@
 
 package com.spotify.github.v3.clients;
 
-import static com.google.common.collect.ImmutableMap.of;
 import static com.google.common.io.Resources.getResource;
 import static java.nio.charset.Charset.defaultCharset;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
-import com.spotify.github.jackson.Json;
 import com.spotify.github.v3.exceptions.RequestNotOkException;
-import com.spotify.github.v3.git.Reference;
 import com.spotify.github.v3.prs.ImmutableRequestReviewParameters;
 import com.spotify.github.v3.prs.PullRequest;
 import com.spotify.github.v3.prs.ReviewRequests;
@@ -59,8 +55,8 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 public class PullRequestClientTest {
@@ -72,7 +68,7 @@ public class PullRequestClientTest {
     return Resources.toString(getResource(PullRequestClientTest.class, resource), defaultCharset());
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     client = mock(OkHttpClient.class);
     github = GitHubClient.create(client, URI.create("http://bogus"), "token");
@@ -227,7 +223,7 @@ public class PullRequestClientTest {
     // Passes without throwing
   }
 
-  @Test(expected = RequestNotOkException.class)
+  @Test
   public void testRemoveRequestedReview_failure() throws Throwable {
 
     final Call call = mock(Call.class);
@@ -254,12 +250,8 @@ public class PullRequestClientTest {
 
     capture.getValue().onResponse(call, response);
 
-    try {
-      result.get();
-    } catch (ExecutionException e) {
-      throw e.getCause();
-      // expecting RequestNotOkException
-    }
+    Exception exception = assertThrows(ExecutionException.class, result::get);
+    assertEquals(RequestNotOkException.class, exception.getCause().getClass());
   }
 
   @Test

--- a/src/test/java/com/spotify/github/v3/clients/RepositoryClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/RepositoryClientTest.java
@@ -37,8 +37,8 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.StreamSupport.stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -69,21 +69,15 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
-import okhttp3.Headers;
 import okhttp3.MediaType;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ Headers.class, ResponseBody.class, Response.class})
 public class RepositoryClientTest {
 
   private GitHubClient github;
@@ -94,7 +88,7 @@ public class RepositoryClientTest {
     return Resources.toString(getResource(RepositoryTest.class, resource), defaultCharset());
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     github = mock(GitHubClient.class);
     repoClient = new RepositoryClient(github, "someowner", "somerepo");

--- a/src/test/java/com/spotify/github/v3/clients/SearchClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/SearchClientTest.java
@@ -35,8 +35,8 @@ import com.spotify.github.v3.search.SearchTest;
 import com.spotify.github.v3.search.requests.ImmutableSearchParameters;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SearchClientTest {
 
@@ -48,7 +48,7 @@ public class SearchClientTest {
     return Resources.toString(getResource(SearchTest.class, resource), defaultCharset());
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     github = mock(GitHubClient.class);
     searchClient = SearchClient.create(github);

--- a/src/test/java/com/spotify/github/v3/clients/TeamClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/TeamClientTest.java
@@ -44,18 +44,11 @@ import com.spotify.github.v3.orgs.requests.TeamUpdate;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import okhttp3.Headers;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Headers.class, ResponseBody.class, Response.class})
 public class TeamClientTest {
 
   private GitHubClient github;
@@ -68,7 +61,7 @@ public class TeamClientTest {
     return Resources.toString(getResource(TeamClientTest.class, resource), defaultCharset());
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     github = mock(GitHubClient.class);
     teamClient = new TeamClient(github, "github");

--- a/src/test/java/com/spotify/github/v3/prs/PullRequestTest.java
+++ b/src/test/java/com/spotify/github/v3/prs/PullRequestTest.java
@@ -29,7 +29,7 @@ import com.google.common.io.Resources;
 import com.spotify.github.jackson.Json;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PullRequestTest {
 

--- a/src/test/java/com/spotify/github/v3/prs/RequestReviewParametersTest.java
+++ b/src/test/java/com/spotify/github/v3/prs/RequestReviewParametersTest.java
@@ -25,7 +25,7 @@ import static org.hamcrest.core.Is.is;
 
 import com.google.common.collect.ImmutableList;
 import com.spotify.github.jackson.Json;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RequestReviewParametersTest {
 

--- a/src/test/java/com/spotify/github/v3/prs/ReviewParametersTest.java
+++ b/src/test/java/com/spotify/github/v3/prs/ReviewParametersTest.java
@@ -20,16 +20,15 @@
 
 package com.spotify.github.v3.prs;
 
-import com.google.common.io.Resources;
-import com.spotify.github.jackson.Json;
-import org.junit.Test;
-
-import java.io.IOException;
-
 import static com.google.common.io.Resources.getResource;
 import static java.nio.charset.Charset.defaultCharset;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+
+import com.google.common.io.Resources;
+import com.spotify.github.jackson.Json;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
 
 public class ReviewParametersTest {
     @Test

--- a/src/test/java/com/spotify/github/v3/prs/ReviewRequestsTest.java
+++ b/src/test/java/com/spotify/github/v3/prs/ReviewRequestsTest.java
@@ -28,8 +28,8 @@ import static org.hamcrest.core.Is.is;
 import com.google.common.io.Resources;
 import com.spotify.github.jackson.Json;
 import java.io.IOException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ReviewRequestsTest {
 
@@ -42,7 +42,7 @@ public class ReviewRequestsTest {
     assertThat(reviewRequests.teams().get(0).slug(), is("justice-league"));
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     fixture = Resources.toString(getResource(this.getClass(), "required_reviews.json"),
         defaultCharset());

--- a/src/test/java/com/spotify/github/v3/prs/ReviewTest.java
+++ b/src/test/java/com/spotify/github/v3/prs/ReviewTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.core.Is.is;
 import com.google.common.io.Resources;
 import com.spotify.github.jackson.Json;
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReviewTest {
   @Test

--- a/src/test/java/com/spotify/github/v3/prs/requests/PullRequestCreateTest.java
+++ b/src/test/java/com/spotify/github/v3/prs/requests/PullRequestCreateTest.java
@@ -20,16 +20,13 @@
 
 package com.spotify.github.v3.prs.requests;
 
-import com.spotify.github.jackson.Json;
-import com.spotify.github.v3.prs.ImmutablePullRequest;
-import org.junit.Assert;
-import org.junit.Test;
-
-import java.util.function.Function;
-
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.spotify.github.jackson.Json;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
 
 public class PullRequestCreateTest {
 

--- a/src/test/java/com/spotify/github/v3/prs/requests/PullRequestParametersTest.java
+++ b/src/test/java/com/spotify/github/v3/prs/requests/PullRequestParametersTest.java
@@ -23,7 +23,7 @@ package com.spotify.github.v3.prs.requests;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PullRequestParametersTest {
 

--- a/src/test/java/com/spotify/github/v3/repos/LanguagesTest.java
+++ b/src/test/java/com/spotify/github/v3/repos/LanguagesTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.core.Is.is;
 import com.google.common.io.Resources;
 import com.spotify.github.jackson.Json;
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LanguagesTest {
 

--- a/src/test/java/com/spotify/github/v3/repos/PushCommitTest.java
+++ b/src/test/java/com/spotify/github/v3/repos/PushCommitTest.java
@@ -28,14 +28,14 @@ import static org.hamcrest.core.Is.is;
 import com.google.common.io.Resources;
 import com.spotify.github.jackson.Json;
 import java.io.IOException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class PushCommitTest {
 
   private String fixture;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     fixture =
         Resources.toString(getResource(this.getClass(), "push_commit.json"), defaultCharset());

--- a/src/test/java/com/spotify/github/v3/repos/RepositoryTest.java
+++ b/src/test/java/com/spotify/github/v3/repos/RepositoryTest.java
@@ -29,14 +29,14 @@ import static org.hamcrest.core.Is.is;
 import com.google.common.io.Resources;
 import com.spotify.github.jackson.Json;
 import java.io.IOException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class RepositoryTest {
 
   private String fixture;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     fixture = Resources.toString(getResource(this.getClass(), "repository.json"), defaultCharset());
   }

--- a/src/test/java/com/spotify/github/v3/repos/StatusTest.java
+++ b/src/test/java/com/spotify/github/v3/repos/StatusTest.java
@@ -30,7 +30,7 @@ import com.spotify.github.jackson.Json;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StatusTest {
 

--- a/src/test/java/com/spotify/github/v3/repos/requests/RepositoryCreateStatusTest.java
+++ b/src/test/java/com/spotify/github/v3/repos/requests/RepositoryCreateStatusTest.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.spotify.github.jackson.Json;
 import com.spotify.github.v3.repos.StatusState;
 import java.net.URI;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RepositoryCreateStatusTest {
 

--- a/src/test/java/com/spotify/github/v3/search/SearchTest.java
+++ b/src/test/java/com/spotify/github/v3/search/SearchTest.java
@@ -30,7 +30,7 @@ import com.spotify.github.jackson.Json;
 import com.spotify.github.v3.issues.Issue;
 import java.io.IOException;
 import java.net.URI;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SearchTest {
 

--- a/src/test/java/com/spotify/github/v3/search/requests/SearchParametersTest.java
+++ b/src/test/java/com/spotify/github/v3/search/requests/SearchParametersTest.java
@@ -23,7 +23,7 @@ package com.spotify.github.v3.search.requests;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SearchParametersTest {
 


### PR DESCRIPTION
The main purpose of this PR is to migrate to Junit 5. Even though we already used some Junit 5 tests, not all tests were migrated. This led to cases where not all tests could be discovered.

With the migration, I reduced the number of direct dependencies and abolished the need to depend on a few old dependencies. Namely, I updated Junit to use the Jupiter Engine and the Jupiter API, okhttp, Mockito, objenesis and the Surefire plugin. Furthermore, I removed the outdated Powermock dependencies because the mapping of final classes is now possible in Mockito.

Side note: Even though the used okhttp packages (`mockwebserver` and `okhttp`) could be updated to version `4.12.0`, I discovered that they indirectly depend on different versions of `kotlin-stdlib-jdk8` and just used version `4.11.0`.