### PR TITLE
chore: ensure compatibility with Java versions 17 and 21

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -9,14 +9,25 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        java-version:
+          - 11
+          - 17
+          - 21
+
+    runs-on: ${{ matrix.os }}
+
     steps:
 
       - uses: actions/checkout@v4
 
       - uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: ${{ matrix.java-version }}
           distribution: corretto
           cache: maven
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ final TeamClient teamClient = organisationClient.createTeamClient();
     teamClient.getMembership("username");
 ```
 
+## Supported Java versions
+
+This library is written and published with Java version 11. In our CI workflows, we execute
+automated tests with the Java LTS versions 11, 17 and 21. Due to Java's backwards compatability,
+this library can definitely be used in all the tested versions.
+
 ## Contributing
 
 This project uses Maven. To run the tests locally, just run:


### PR DESCRIPTION
This PR builds on top of the two previous PRs #156 and #157. After merging these two PRs, the branch of this PR should be rebased on top of `master`.

As the involved version upgrades enable the compatibility with newer Java versions, the tests should then succeed in the three different Java versions `11`, `17` and `21`.

After merging this PR, we can upgrade the version of the library to `0.2.0`.