### PR TITLE
Add non static alternative to GitHubClient scopeForInstallationId

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/GitHubClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/GitHubClient.java
@@ -319,6 +319,19 @@ public class GitHubClient {
     }
   }
 
+  public GitHubClient withScopeForInstallationId(final int installationId) {
+    if (Optional.ofNullable(privateKey).isEmpty()) {
+      throw new RuntimeException("Installation ID scoped client needs a private key");
+    }
+    return new GitHubClient(
+        client,
+        baseUrl,
+        null,
+        privateKey,
+        appId,
+        installationId);
+  }
+
   public GitHubClient withTracer(final Tracer tracer) {
     this.tracer = tracer;
     return this;

--- a/src/test/java/com/spotify/github/v3/clients/GitHubClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/GitHubClientTest.java
@@ -36,8 +36,11 @@ import com.spotify.github.v3.exceptions.ReadOnlyRepositoryException;
 import com.spotify.github.v3.exceptions.RequestNotOkException;
 import com.spotify.github.v3.repos.CommitItem;
 import com.spotify.github.v3.repos.RepositoryInvitation;
+
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -68,6 +71,19 @@ public class GitHubClientTest {
   public void setUp() {
     client = mock(OkHttpClient.class);
     github = GitHubClient.create(client, URI.create("http://bogus"), "token");
+  }
+
+  @Test
+  public void withScopedInstallationIdShouldFailWhenMissingPrivateKey() {
+    assertThrows(RuntimeException.class, () -> github.withScopeForInstallationId(1));
+  }
+
+  @Test
+  public void testWithScopedInstallationId() throws URISyntaxException {
+    GitHubClient org = GitHubClient.create(new URI("http://apa.bepa.cepa"), "some_key_content".getBytes(), null, null);
+    GitHubClient scoped = org.withScopeForInstallationId(1);
+    Assertions.assertTrue(scoped.getPrivateKey().isPresent());
+    Assertions.assertEquals(org.getPrivateKey().get(), scoped.getPrivateKey().get());
   }
 
   @Test


### PR DESCRIPTION
[What]
Add non static alternative to GitHubClient scopeForInstallationId

[Why]
It makes it easier to mock github client within your project that is using github client