### PR TITLE
docs: HOTS-374 add maintainers team to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,9 @@ In time, we'll tag issues that would make a good first pull request for new cont
 way to get started helping the project is to *file an issue*. Issues can include bugs to fix, 
 features to add, or documentation that looks outdated.
 
+This library is maintained by @spotify/gjc-maintainers. If you have any questions or issues, please
+tag this team in the relevant PR/issue.
+
 ## Contributions
 
 This project welcomes contributions from everyone.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ In time, we'll tag issues that would make a good first pull request for new cont
 way to get started helping the project is to *file an issue*. Issues can include bugs to fix, 
 features to add, or documentation that looks outdated.
 
-This library is maintained by @spotify/gjc-maintainers. If you have any questions or issues, please
-tag this team in the relevant PR/issue.
+This library is maintained by @spotify/gjc-maintainers. If you have any questions, issues or need a 
+review, please tag this team in the relevant PR/issue.
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@
 ![Maven Central](https://img.shields.io/maven-central/v/com.spotify/github-client)
 
 
-# github-client
+# github-java-client
 
 A small Java library for talking to GitHub/GitHub Enterprise and interacting with projects.
 
 It supports authentication via simple access tokens, JWT endpoints and GitHub Apps (via private key).
 
 It is also very light on GitHub, doing as few requests as necessary.
+
+This library is maintained by @spotify/gjc-maintainers. If you have any questions or issues, please 
+tag this team in the relevant PR/issue.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ It supports authentication via simple access tokens, JWT endpoints and GitHub Ap
 
 It is also very light on GitHub, doing as few requests as necessary.
 
-This library is maintained by @spotify/gjc-maintainers. If you have any questions or issues, please 
-tag this team in the relevant PR/issue.
+This library is maintained by @spotify/gjc-maintainers. If you have any questions, issues or need a
+review, please tag this team in the relevant PR/issue.
 
 ## Getting Started
 


### PR DESCRIPTION
### What does this PR do?

Adds the maintainers team to the docs so external users are aware of who to reach out to for review or for any questions.