### PR TITLE
chore: declare ownership according to `OS Project Ownership` docs

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,4 +4,4 @@ metadata:
   name: github-java-client
 spec:
   type: resource
-  owner: pipedream
+  owner: hotsauce


### PR DESCRIPTION
As declared in our `Open Source Project Ownership` docs, we need to declare the library ownership in the `catalog-info.yaml`. As the ownership changed to `HotSauce` and we want to be accountable, we should update this declaration.