### PR TITLE
fix(README): fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ It supports authentication via simple access tokens, JWT endpoints and GitHub Ap
 
 It is also very light on GitHub, doing as few requests as necessary.
 
-You can find this library in [maven central repository](https://mvnrepository.com/artifact/com.spotify/github-client).
-
 This library is maintained by @spotify/gjc-maintainers. If you have any questions, issues or need a
 review, please tag this team in the relevant PR/issue.
 
 ## Getting Started
+
+You can find this library in [maven central repository](https://mvnrepository.com/artifact/com.spotify/github-client).
 
 Include the latest version of github-client into your project:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-![maven](https://github.com/spotify/github-client/workflows/maven/badge.svg)
+![release pipeline](https://github.com/spotify/github-java-client/actions/workflows/release.yml/badge.svg)
 [![codecov](https://codecov.io/gh/spotify/github-java-client/branch/master/graph/badge.svg?token=ADHNCIESSL)](https://codecov.io/gh/spotify/github-java-client)[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 ![lifecycle: beta](https://img.shields.io/badge/lifecycle-beta-509bf5.svg)
-![Maven Central](https://img.shields.io/maven-central/v/com.spotify/github-client)
+[![Maven Central](https://img.shields.io/maven-central/v/com.spotify/github-client)](https://mvnrepository.com/artifact/com.spotify/github-client)
 
 
 # github-java-client
@@ -11,6 +11,8 @@ A small Java library for talking to GitHub/GitHub Enterprise and interacting wit
 It supports authentication via simple access tokens, JWT endpoints and GitHub Apps (via private key).
 
 It is also very light on GitHub, doing as few requests as necessary.
+
+You can find this library in [maven central repository](https://mvnrepository.com/artifact/com.spotify/github-client).
 
 This library is maintained by @spotify/gjc-maintainers. If you have any questions, issues or need a
 review, please tag this team in the relevant PR/issue.


### PR DESCRIPTION
Summary
=======

This PR fixes the worklow badges link and add links to our maven central page both from the badge and in the text.