### PR TITLE
cd: create workflow to trigger release on GitHub

### DIFF
--- a/.github/workflows/release-on-github.yml
+++ b/.github/workflows/release-on-github.yml
@@ -1,0 +1,23 @@
+name: github-release
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Create GitHub release
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/spotify/github-java-client/releases \
+            -d '{"tag_name":"${{ inputs.tag }}","target_commitish":"master","draft":false,"prerelease":false,"generate_release_notes":true}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,12 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+
+  trigger-github-release:
+    needs: build
+    name: Trigger GitHub release workflow
+    if: github.ref_type == 'tag'
+    uses: ./.github/workflows/release-on-github.yml
+    with:
+      tag: ${{ github.ref_name }}


### PR DESCRIPTION
The action `github-release` triggers a release on GitHub. Usually, such a release should happen when a new tag is created. As the release notes should be generated automatically and the proper notes are only available after running Maven deploy, the GitHub release gets triggered only when the workflow `maven-release` is finished.