### PR TITLE
cd: allow manual release on GitHub through workflow

### DIFF
--- a/.github/workflows/release-on-github.yml
+++ b/.github/workflows/release-on-github.yml
@@ -1,6 +1,12 @@
 name: github-release
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Create GitHub release of following tag
+        required: true
+        type: string
   workflow_call:
     inputs:
       tag:


### PR DESCRIPTION
The GitHub release did not get triggered. To work around issues like this, we should enable triggering the GitHub release manually through the web UI.