### PR TITLE
cd: retrieve tag for current SHA and trigger GitHub release with this tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,27 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
 
-  trigger-github-release:
+  get-tag-of-current-sha:
     needs: build
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag-retriever.outputs.tag }}
+      # Var is empty if command to retrieve tag fails (e.g. if current SHA has no tag associated)
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - name: Store tag of SHA if present
+        id: tag-retriever
+        run: |
+          echo "tag=$(git describe --exact-match ${{ github.sha }})" >> "$GITHUB_OUTPUT"
+
+
+  trigger-github-release:
+    needs: get-tag-of-current-sha
     name: Trigger GitHub release workflow
-    if: github.ref_type == 'tag'
+    if: needs.get-tag-of-current-sha.outputs.tag
+    # Runs job only if tag is present.
     uses: ./.github/workflows/release-on-github.yml
     with:
-      tag: ${{ github.ref_name }}
+      tag: ${{ needs.get-tag-of-current-sha.outputs.tag }}

--- a/README.md
+++ b/README.md
@@ -104,22 +104,16 @@ This project uses Maven. To run the tests locally, just run:
 mvn clean verify
 ```
 
-If you are a maintainer, you can release a new version by doing the following:
-
-- Trigger the workflow [prepare-release](./.github/workflows/prepare-release.yml) through the
-  [web UI](https://github.com/spotify/github-java-client/actions/workflows/prepare-release.yml)
-  - Select whether the new release should be a `major`, `minor` or `patch` release
-  - Trigger the release preparation on the `master` branch
-  - Pushes of this workflow will trigger runs of the workflow
-    [release](https://github.com/spotify/github-java-client/actions/workflows/release.yml)
-- Once the
-  [release pipeline](https://github.com/spotify/github-java-client/actions/workflows/release.yml)
-  has completed for the release tag, the new release will be available on Maven Central and the
-  changes can be released on GitHub
-- [Navigate to the tag](https://github.com/spotify/github-java-client/tags) associated with the
-  changes and generate a manual release
-- Once the release is generated, select the "Set as the latest release" checkbox and publish the
-  release
+If you are a maintainer, you can release a new version by just triggering the workflow 
+[prepare-release](./.github/workflows/prepare-release.yml) through the 
+[web UI](https://github.com/spotify/github-java-client/actions/workflows/prepare-release.yml).
+- Select whether the new release should be a `major`, `minor` or `patch` release
+- Trigger the release preparation on the `master` branch
+- Pushes of this workflow will trigger runs of the
+  [maven-release](https://github.com/spotify/github-java-client/actions/workflows/release.yml)
+  workflow, which in turn will trigger the
+  [github-release](https://github.com/spotify/github-java-client/actions/workflows/release-on-github.yml)
+  workflow with the automatically created tag
 
 ## Notes about maturity
 


### PR DESCRIPTION
As the `maven-release` workflow gets only triggered by the master ref and not by the tag, I added the functionality to retrieve the tag associated with the current SHA. If a tag is available for the current SHA, I trigger a GitHub release with this tag.