### PR TITLE
fix(cd): enable tag retrieval through increasing `fetch-depth`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,10 @@ jobs:
       # Var is empty if command to retrieve tag fails (e.g. if current SHA has no tag associated)
     steps:
 
-      - uses: actions/checkout@v4
+      - name: Clone repo with complete history and tags
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Store tag of SHA if present
         id: tag-retriever


### PR DESCRIPTION
For using `git describe` and retrieving a successful result, the Git history including the tags has to be present. The issue is that `actions/checkout` performs a shallow clone of the depth `1`, i.e. a clone without history.

In our case, we might only require the history with tags from HEAD until the currently checked-out commit. As this library's history is not the biggest and we currently do not observe performance issues, I decided to not perform a premature optimisation and just check out the whole Git history with tags.