### PR TITLE
Add paged version of getTeamMembers

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/TeamClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/TeamClient.java
@@ -21,11 +21,9 @@
 
 package com.spotify.github.v3.clients;
 
-import static com.spotify.github.v3.clients.GitHubClient.IGNORE_RESPONSE_CONSUMER;
-import static com.spotify.github.v3.clients.GitHubClient.LIST_PENDING_TEAM_INVITATIONS;
-import static com.spotify.github.v3.clients.GitHubClient.LIST_TEAMS;
-import static com.spotify.github.v3.clients.GitHubClient.LIST_TEAM_MEMBERS;
+import static com.spotify.github.v3.clients.GitHubClient.*;
 
+import com.spotify.github.async.AsyncPage;
 import com.spotify.github.v3.Team;
 import com.spotify.github.v3.User;
 import com.spotify.github.v3.orgs.Membership;
@@ -34,6 +32,7 @@ import com.spotify.github.v3.orgs.requests.MembershipCreate;
 import com.spotify.github.v3.orgs.requests.TeamCreate;
 import com.spotify.github.v3.orgs.requests.TeamUpdate;
 import java.lang.invoke.MethodHandles;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
@@ -48,6 +47,8 @@ public class TeamClient {
   private static final String TEAM_SLUG_TEMPLATE = "/orgs/%s/teams/%s";
 
   private static final String MEMBERS_TEMPLATE = "/orgs/%s/teams/%s/members";
+
+  private static final String PAGED_MEMBERS_TEMPLATE = "/orgs/%s/teams/%s/members?per_page=%d";
 
   private static final String MEMBERSHIP_TEMPLATE = "/orgs/%s/teams/%s/memberships/%s";
 
@@ -161,6 +162,19 @@ public class TeamClient {
     final String path = String.format(MEMBERS_TEMPLATE, org, slug);
     log.debug("Fetching members for: " + path);
     return github.request(path, LIST_TEAM_MEMBERS);
+  }
+
+  /**
+   * List members of a specific team.
+   *
+   * @param slug the team slug
+   * @param pageSize the number of users to fetch per page
+   * @return list of all users in a team
+   */
+  public Iterator<AsyncPage<User>> listTeamMembers(final String slug, final int pageSize) {
+    final String path = String.format(PAGED_MEMBERS_TEMPLATE, org, slug, pageSize);
+    log.debug("Fetching members for: " + path);
+    return new GithubPageIterator<>(new GithubPage<>(github, path, LIST_TEAM_MEMBERS));
   }
 
   /**

--- a/src/test/resources/com/spotify/github/v3/clients/list_members_page1.json
+++ b/src/test/resources/com/spotify/github/v3/clients/list_members_page1.json
@@ -1,0 +1,22 @@
+[
+  {
+    "login": "octocat",
+    "id": 1,
+    "node_id": "MDQ6VXNlcjE=",
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/octocat",
+    "html_url": "https://github.com/octocat",
+    "followers_url": "https://api.github.com/users/octocat/followers",
+    "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+    "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+    "organizations_url": "https://api.github.com/users/octocat/orgs",
+    "repos_url": "https://api.github.com/users/octocat/repos",
+    "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/octocat/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+]

--- a/src/test/resources/com/spotify/github/v3/clients/list_members_page2.json
+++ b/src/test/resources/com/spotify/github/v3/clients/list_members_page2.json
@@ -1,0 +1,22 @@
+[
+  {
+    "login": "octocat2",
+    "id": 2,
+    "node_id": "MDQ2VXNlcjE=",
+    "avatar_url": "https://github.com/images/error/octocat2_happy.gif",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/octocat2",
+    "html_url": "https://github.com/octocat2",
+    "followers_url": "https://api.github.com/users/octocat2/followers",
+    "following_url": "https://api.github.com/users/octoca2t/following{/other_user}",
+    "gists_url": "https://api.github.com/users/octocat2/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/octocat2/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/octocat2/subscriptions",
+    "organizations_url": "https://api.github.com/users/octocat2/orgs",
+    "repos_url": "https://api.github.com/users/octocat2/repos",
+    "events_url": "https://api.github.com/users/octocat2/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/octocat2/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+]


### PR DESCRIPTION
Github will list up to 30 team members by default when retrieving members from a team. If there is more that 30 members we need to iterate over the paged api.