### PR TITLE
chore: update version of `nexus-staging-maven-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.8</version>
+                        <version>1.6.13</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>


### PR DESCRIPTION
Some runs of the release action fail. The failures seem to occur because of the `nexus-staging-maven-plugin`. With a version which is around 5 years younger, the release action should become more reliable.