### PR TITLE
BUG SearchIssue id can be bigger than Integer.MAX

### DIFF
--- a/src/main/java/com/spotify/github/v3/issues/Issue.java
+++ b/src/main/java/com/spotify/github/v3/issues/Issue.java
@@ -41,7 +41,7 @@ public interface Issue extends CloseTracking {
 
   /** ID. */
   @Nullable
-  Integer id();
+  Long id();
 
   /** URL. */
   @Nullable

--- a/src/test/java/com/spotify/github/v3/clients/SearchClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/SearchClientTest.java
@@ -63,6 +63,6 @@ public class SearchClientTest {
     when(github.request(ISSUES_URI + "?q=bogus-q", SearchIssues.class)).thenReturn(fixture);
     final SearchIssues search =
         searchClient.issues(ImmutableSearchParameters.builder().q("bogus-q").build()).get();
-    assertSearchIssues(search);
+    assertSearchIssues(search, 35802);
   }
 }

--- a/src/test/java/com/spotify/github/v3/search/SearchTest.java
+++ b/src/test/java/com/spotify/github/v3/search/SearchTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 
 public class SearchTest {
 
-  public static final void assertSearchIssues(final SearchIssues search) {
+  public static final void assertSearchIssues(final SearchIssues search, long id) {
     final Issue issues = search.items().get(0);
     assertThat(search.totalCount(), is(280));
     assertThat(search.incompleteResults(), is(false));
@@ -42,7 +42,7 @@ public class SearchTest {
         issues.url(),
         is(URI.create("https://api.github.com/repos/batterseapower/pinyin-toolkit/issues/132")));
     assertThat(issues.number(), is(132));
-    assertThat(issues.id(), is(35802));
+    assertThat(issues.id(), is(id));
     assertThat(issues.title(), is("Line Number Indexes Beyond 20 Not Displayed"));
   }
 
@@ -52,6 +52,15 @@ public class SearchTest {
         Resources.toString(getResource(this.getClass(), "issues.json"), defaultCharset());
 
     final SearchIssues search = Json.create().fromJson(fixture, SearchIssues.class);
-    assertSearchIssues(search);
+    assertSearchIssues(search, 35802);
+  }
+
+  @Test
+  public void testDeserializationWithLargeIssueId() throws IOException {
+    final String fixture =
+        Resources.toString(getResource(this.getClass(), "issues-with-large-id.json"), defaultCharset());
+
+    final SearchIssues search = Json.create().fromJson(fixture, SearchIssues.class);
+    assertSearchIssues(search, 2147534768L);
   }
 }


### PR DESCRIPTION
Represent it as Long instead of Integer.

For schema (where id is specified as 'int64') see:

https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-issues-and-pull-requests