### PR TITLE
Propagate graphql url to installation scoped client

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/GitHubClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/GitHubClient.java
@@ -360,7 +360,7 @@ public class GitHubClient {
     return new GitHubClient(
         client,
         baseUrl,
-        null,
+        graphqlUrl.orElse(null),
         null,
         privateKey,
         appId,


### PR DESCRIPTION
This is needed if you want to use the installationScopedClient with graphql api method. Otherwise we get following exception "Graphql url is not set".