### PR TITLE
Add repository_dispatch endpoint

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
@@ -85,6 +85,7 @@ public class RepositoryClient {
   private static final String BRANCH_TEMPLATE = "/repos/%s/%s/branches/%s";
   private static final String LIST_BRANCHES_TEMPLATE = "/repos/%s/%s/branches";
   private static final String CREATE_COMMENT_TEMPLATE = "/repos/%s/%s/commits/%s/comments";
+  private static final String CREATE_REPOSITORY_DISPATCH_EVENT_TEMPLATE = "/repos/%s/%s/dispatches";
   private static final String COMMENT_TEMPLATE = "/repos/%s/%s/comments/%s";
   private static final String LANGUAGES_TEMPLATE = "/repos/%s/%s/languages";
   private static final String MERGE_TEMPLATE = "/repos/%s/%s/merges";
@@ -697,5 +698,19 @@ public class RepositoryClient {
       throw new IllegalArgumentException(path + " starts or ends with '/'");
     }
     return String.format(CONTENTS_URI_TEMPLATE, owner, repo, path, query);
+  }
+
+  /**
+   * Create a repository_dispatch event.
+   *
+   * @param request The repository dispatch request.
+   */
+
+  private CompletableFuture<Void> createRepositoryDispatchEvent(RepositoryDispatch request) {
+    final String path = String.format(CREATE_REPOSITORY_DISPATCH_EVENT_TEMPLATE, repo, owner);
+
+    return github
+        .post(path, github.json().toJsonUnchecked(request))
+        .thenAccept(IGNORE_RESPONSE_CONSUMER); //Should return a 204 for happy flow. 
   }
 }

--- a/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
@@ -711,6 +711,6 @@ public class RepositoryClient {
 
     return github
         .post(path, github.json().toJsonUnchecked(request))
-        .thenAccept(IGNORE_RESPONSE_CONSUMER); //Should return a 204 for happy flow. 
+        .thenAccept(IGNORE_RESPONSE_CONSUMER); //Should return a 204 for happy flow.
   }
 }

--- a/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
@@ -60,6 +60,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import javax.ws.rs.core.HttpHeaders;
+import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -706,11 +707,10 @@ public class RepositoryClient {
    * @param request The repository dispatch request.
    */
 
-  public CompletableFuture<Void> createRepositoryDispatchEvent(final RepositoryDispatch request) {
+  public CompletableFuture<Boolean> createRepositoryDispatchEvent(final RepositoryDispatch request) {
     final String path = String.format(CREATE_REPOSITORY_DISPATCH_EVENT_TEMPLATE, owner, repo);
-
     return github
         .post(path, github.json().toJsonUnchecked(request))
-        .thenAccept(IGNORE_RESPONSE_CONSUMER); //Should return a 204 with an empty response body.
+        .thenApply(response -> response.code() == NO_CONTENT); //should always return a 204
   }
 }

--- a/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
@@ -706,7 +706,7 @@ public class RepositoryClient {
    * @param request The repository dispatch request.
    */
 
-  private CompletableFuture<Void> createRepositoryDispatchEvent(final RepositoryDispatch request) {
+  public CompletableFuture<Void> createRepositoryDispatchEvent(final RepositoryDispatch request) {
     final String path = String.format(CREATE_REPOSITORY_DISPATCH_EVENT_TEMPLATE, owner, repo);
 
     return github

--- a/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
@@ -60,7 +60,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import javax.ws.rs.core.HttpHeaders;
-import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
@@ -706,7 +706,7 @@ public class RepositoryClient {
    * @param request The repository dispatch request.
    */
 
-  private CompletableFuture<Void> createRepositoryDispatchEvent(RepositoryDispatch request) {
+  private CompletableFuture<Void> createRepositoryDispatchEvent(final RepositoryDispatch request) {
     final String path = String.format(CREATE_REPOSITORY_DISPATCH_EVENT_TEMPLATE, owner, repo);
 
     return github

--- a/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
@@ -707,7 +707,7 @@ public class RepositoryClient {
    */
 
   private CompletableFuture<Void> createRepositoryDispatchEvent(RepositoryDispatch request) {
-    final String path = String.format(CREATE_REPOSITORY_DISPATCH_EVENT_TEMPLATE, repo, owner);
+    final String path = String.format(CREATE_REPOSITORY_DISPATCH_EVENT_TEMPLATE, owner, repo);
 
     return github
         .post(path, github.json().toJsonUnchecked(request))

--- a/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
@@ -711,6 +711,6 @@ public class RepositoryClient {
 
     return github
         .post(path, github.json().toJsonUnchecked(request))
-        .thenAccept(IGNORE_RESPONSE_CONSUMER); //Should return a 204 for happy flow.
+        .thenAccept(IGNORE_RESPONSE_CONSUMER); //Should return a 204 with an empty response body.
   }
 }

--- a/src/main/java/com/spotify/github/v3/repos/requests/RepositoryDispatch.java
+++ b/src/main/java/com/spotify/github/v3/repos/requests/RepositoryDispatch.java
@@ -1,3 +1,23 @@
+/*-
+ * -\-\-
+ * github-api
+ * --
+ * Copyright (C) 2016 - 2023 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
 package com.spotify.github.v3.repos.requests;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/main/java/com/spotify/github/v3/repos/requests/RepositoryDispatch.java
+++ b/src/main/java/com/spotify/github/v3/repos/requests/RepositoryDispatch.java
@@ -39,7 +39,6 @@ public interface RepositoryDispatch {
 
   /** JSON payload with extra information about the webhook event
   * that your action or workflow may use. */
-  @Nullable
   Optional<JsonNode> clientPayload();
 
 }

--- a/src/main/java/com/spotify/github/v3/repos/requests/RepositoryDispatch.java
+++ b/src/main/java/com/spotify/github/v3/repos/requests/RepositoryDispatch.java
@@ -1,0 +1,25 @@
+package com.spotify.github.v3.repos.requests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.spotify.github.GithubStyle;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@GithubStyle
+@JsonSerialize(as = ImmutableRepositoryDispatch.class)
+@JsonDeserialize(as = ImmutableRepositoryDispatch.class)
+public interface RepositoryDispatch {
+
+  /** The custom webhook event name */
+  String eventType();
+
+  /** JSON payload with extra information about the webhook event
+  * that your action or workflow may use. */
+  @Nullable
+  Optional<JsonNode> clientPayload();
+
+}

--- a/src/main/java/com/spotify/github/v3/repos/requests/RepositoryDispatch.java
+++ b/src/main/java/com/spotify/github/v3/repos/requests/RepositoryDispatch.java
@@ -34,6 +34,7 @@ import org.immutables.value.Value;
 public interface RepositoryDispatch {
 
   /** The custom webhook event name */
+
   String eventType();
 
   /** JSON payload with extra information about the webhook event

--- a/src/main/java/com/spotify/github/v3/repos/requests/RepositoryDispatch.java
+++ b/src/main/java/com/spotify/github/v3/repos/requests/RepositoryDispatch.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.spotify.github.GithubStyle;
 import java.util.Optional;
-import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
 @Value.Immutable

--- a/src/test/java/com/spotify/github/v3/clients/RepositoryClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/RepositoryClientTest.java
@@ -77,7 +77,6 @@ import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;

--- a/src/test/java/com/spotify/github/v3/clients/RepositoryClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/RepositoryClientTest.java
@@ -42,7 +42,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;

--- a/src/test/java/com/spotify/github/v3/clients/RepositoryClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/RepositoryClientTest.java
@@ -42,6 +42,8 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
@@ -71,6 +73,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import okhttp3.MediaType;
 import okhttp3.Protocol;
@@ -713,6 +716,27 @@ public class RepositoryClientTest {
 
     Optional<InputStream> response = repoClient.downloadZipball("master").get();
     assertThat(response, is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldReturnEmptyResponseWhenRepositoryDispatchEndpointTriggered() throws Exception {
+    final Response response = mock(Response.class);
+    when(response.code()).thenReturn(204);
+
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode clientPayload = mapper.createObjectNode();
+    clientPayload.put("my-custom-true-property","true");
+    clientPayload.put("my-custom-false-property", "false");
+
+    RepositoryDispatch repositoryDispatchRequest = ImmutableRepositoryDispatch.builder()
+        .eventType("my-custom-event")
+        .clientPayload(clientPayload)
+        .build();
+
+    when(github.post("/repos/someowner/somerepo/dispatches", json.toJsonUnchecked(repositoryDispatchRequest))).thenReturn(completedFuture(response));
+
+    boolean repoDispatchResult = repoClient.createRepositoryDispatchEvent(repositoryDispatchRequest).get();
+    assertTrue(repoDispatchResult);
   }
 
 }

--- a/src/test/java/com/spotify/github/v3/clients/RepositoryClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/RepositoryClientTest.java
@@ -42,6 +42,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
@@ -77,6 +78,7 @@ import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -714,4 +716,5 @@ public class RepositoryClientTest {
     Optional<InputStream> response = repoClient.downloadZipball("master").get();
     assertThat(response, is(Optional.empty()));
   }
+
 }


### PR DESCRIPTION
Adding support for the `/repos/{owner}/{repo}/dispatches` endpoint that allows us to dispatch custom webhook events from repositories to trigger workflows. See more here: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event