### PR TITLE
Add `asAppScopedClient()` function for convenience

### DIFF
--- a/src/main/java/com/spotify/github/async/Async.java
+++ b/src/main/java/com/spotify/github/async/Async.java
@@ -20,6 +20,8 @@
 
 package com.spotify.github.async;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static java.util.stream.StreamSupport.stream;
@@ -33,5 +35,20 @@ public class Async {
     public static <T> Stream<T> streamFromPaginatingIterable(final Iterable<AsyncPage<T>> iterable) {
         return stream(iterable.spliterator(), false)
                    .flatMap(page -> stream(page.spliterator(), false));
+    }
+
+    public static <T> CompletableFuture<T> exceptionallyCompose(
+            final CompletableFuture<T> future, final Function<Throwable, CompletableFuture<T>> handler) {
+
+        return future
+                .handle(
+                        (result, throwable) -> {
+                            if (throwable != null) {
+                                return handler.apply(throwable);
+                            } else {
+                                return CompletableFuture.completedFuture(result);
+                            }
+                        })
+                .thenCompose(Function.identity());
     }
 }

--- a/src/main/java/com/spotify/github/v3/clients/GitHubClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/GitHubClient.java
@@ -383,7 +383,7 @@ public class GitHubClient {
                         .createGithubAppClient()
                         .getInstallation()
                         .thenApply(Installation::id), e -> {
-                    if (e.getCause() instanceof RequestNotOkException && ((RequestNotOkException) e).statusCode() == HTTP_NOT_FOUND) {
+                    if (e.getCause() instanceof RequestNotOkException && ((RequestNotOkException) e.getCause()).statusCode() == HTTP_NOT_FOUND) {
                         return this
                                 .createUserClient(owner)
                                 .createGithubAppClient()
@@ -395,7 +395,7 @@ public class GitHubClient {
                 .thenApply(id -> Optional.of(this.withScopeForInstallationId(id)))
                 .exceptionally(
                         e -> {
-                            if (e.getCause() instanceof RequestNotOkException && ((RequestNotOkException) e).statusCode() == HTTP_NOT_FOUND) {
+                            if (e.getCause() instanceof RequestNotOkException && ((RequestNotOkException) e.getCause()).statusCode() == HTTP_NOT_FOUND) {
                                 return Optional.empty();
                             }
                             throw new RuntimeException(e);


### PR DESCRIPTION
It can be tricky to know which installation ID to provide to `withScopeForInstallationId`.
Rather than duplicating the "check for an organization installation, then check for a user installation", let's instead move that to this library so it can be reused.

This is a slow operation, but caching of the result can be handled by consumers (if needed) IMO.