### PR TITLE
Add get and list workflows from github actions API

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/ActionsClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/ActionsClient.java
@@ -1,0 +1,46 @@
+/*-
+ * -\-\-
+ * github-api
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.github.v3.clients;
+
+public class ActionsClient {
+  private final String owner;
+  private final String repo;
+  private final GitHubClient github;
+
+  ActionsClient(final GitHubClient github, final String owner, final String repo) {
+    this.github = github;
+    this.owner = owner;
+    this.repo = repo;
+  }
+
+  static ActionsClient create(final GitHubClient github, final String owner, final String repo) {
+    return new ActionsClient(github, owner, repo);
+  }
+
+  /**
+   * Workflows API client
+   *
+   * @return Workflows API client
+   */
+  public WorkflowsClient createWorkflowsClient() {
+    return WorkflowsClient.create(github, owner, repo);
+  }
+}

--- a/src/main/java/com/spotify/github/v3/clients/GitHubClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/GitHubClient.java
@@ -475,15 +475,6 @@ public class GitHubClient {
     return UserClient.create(this, owner);
   }
 
-  /**
-   * Workflows API client
-   *
-   * @return Workflows API client
-   */
-  public WorkflowsClient createWorkflowsClient(final String owner, final String repo) {
-    return WorkflowsClient.create(this, owner, repo);
-  }
-
   Json json() {
     return json;
   }

--- a/src/main/java/com/spotify/github/v3/clients/GitHubClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/GitHubClient.java
@@ -475,6 +475,15 @@ public class GitHubClient {
     return UserClient.create(this, owner);
   }
 
+  /**
+   * Workflows API client
+   *
+   * @return Workflows API client
+   */
+  public WorkflowsClient createWorkflowsClient(final String owner, final String repo) {
+    return WorkflowsClient.create(this, owner, repo);
+  }
+
   Json json() {
     return json;
   }

--- a/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/RepositoryClient.java
@@ -151,6 +151,15 @@ public class RepositoryClient {
   }
 
   /**
+   * Actions API client
+   *
+   * @return Actions API client
+   */
+  public ActionsClient createActionsClient() {
+    return ActionsClient.create(github, owner, repo);
+  }
+
+  /**
    * Get information about this repository.
    *
    * @return repository information

--- a/src/main/java/com/spotify/github/v3/clients/WorkflowsClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/WorkflowsClient.java
@@ -1,0 +1,73 @@
+/*-
+ * -\-\-
+ * github-api
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.github.v3.clients;
+
+import com.google.common.collect.ImmutableMap;
+import com.spotify.github.v3.workflows.WorkflowsRepositoryResponseList;
+import com.spotify.github.v3.workflows.WorkflowsResponse;
+
+import javax.ws.rs.core.HttpHeaders;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/** Workflows API client */
+public class WorkflowsClient {
+  private static final String LIST_REPOSITORY_WORKFLOWS_URI = "/repos/%s/%s/actions/workflows";
+  private static final String GET_WORKFLOW_URI = "/repos/%s/%s/actions/workflows/%s";
+
+  private final GitHubClient github;
+  private final String owner;
+  private final String repo;
+
+  private final Map<String, String> extraHeaders =
+      ImmutableMap.of(HttpHeaders.ACCEPT, "application/vnd.github+json");
+
+  public WorkflowsClient(final GitHubClient github, final String owner, final String repo) {
+    this.github = github;
+    this.owner = owner;
+    this.repo = repo;
+  }
+
+  static WorkflowsClient create(final GitHubClient github, final String owner, final String repo) {
+    return new WorkflowsClient(github, owner, repo);
+  }
+
+  /**
+   * List workflows for a repository.
+   *
+   * @return a list of workflows for the repository
+   */
+  public CompletableFuture<WorkflowsRepositoryResponseList> listWorkflows() {
+    final String path = String.format(LIST_REPOSITORY_WORKFLOWS_URI, owner, repo);
+    return github.request(path, WorkflowsRepositoryResponseList.class, extraHeaders);
+  }
+
+  /**
+   * Gets a workflow by id.
+   *
+   * @param id the workflow id
+   * @return a WorkflowsResponse
+   */
+  public CompletableFuture<WorkflowsResponse> getWorkflow(final int id) {
+    final String path = String.format(GET_WORKFLOW_URI, owner, repo, id);
+    return github.request(path, WorkflowsResponse.class, extraHeaders);
+  }
+}

--- a/src/main/java/com/spotify/github/v3/workflows/WorkflowsRepositoryResponseList.java
+++ b/src/main/java/com/spotify/github/v3/workflows/WorkflowsRepositoryResponseList.java
@@ -1,0 +1,51 @@
+/*-
+ * -\-\-
+ * github-api
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.github.v3.workflows;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.spotify.github.GithubStyle;
+import org.immutables.value.Value;
+
+import java.util.List;
+
+/**
+ * The WorkflowsResponse list resource
+ *
+ * @see "https://docs.github.com/en/rest/actions/workflows#list-repository-workflows"
+ */
+@Value.Immutable
+@GithubStyle
+@JsonDeserialize(as = ImmutableWorkflowsRepositoryResponseList.class)
+public interface WorkflowsRepositoryResponseList {
+  /**
+   * The count of workflows in the response
+   *
+   * @return the int
+   */
+  int totalCount();
+
+  /**
+   * Workflows list.
+   *
+   * @return the list of workflows
+   */
+  List<WorkflowsResponse> workflows();
+}

--- a/src/main/java/com/spotify/github/v3/workflows/WorkflowsResponse.java
+++ b/src/main/java/com/spotify/github/v3/workflows/WorkflowsResponse.java
@@ -1,0 +1,93 @@
+/*-
+ * -\-\-
+ * github-api
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.github.v3.workflows;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.spotify.github.GithubStyle;
+import org.immutables.value.Value;
+
+import java.time.ZonedDateTime;
+
+@Value.Immutable
+@GithubStyle
+@JsonDeserialize(as = ImmutableWorkflowsResponse.class)
+public interface WorkflowsResponse {
+    /**
+     * The Workflow ID.
+     *
+     * @return the int
+     */
+    int id();
+
+    /** Node ID */
+    String nodeId();
+
+    /** Name. */
+    String name();
+
+    /** The workflow path. */
+    String path();
+
+    /** Indicates the state of the workflow. */
+    WorkflowsState state();
+
+    /**
+     * Created At
+     *
+     * @return The time when the workflow was created
+     */
+    ZonedDateTime createdAt();
+
+    /**
+     * Updated At
+     *
+     * @return The time when the workflow was updated
+     */
+    ZonedDateTime updatedAt();
+
+    /**
+     * Deleted At
+     *
+     * @return The time when the workflow was updated
+     */
+    ZonedDateTime deletedAt();
+
+    /**
+     * Url string.
+     *
+     * @return the string
+     */
+    String url();
+
+    /**
+     * Html url string.
+     *
+     * @return the string
+     */
+    String htmlUrl();
+
+    /**
+     * Badge Url string.
+     *
+     * @return the string
+     */
+    String badgeUrl();
+}

--- a/src/main/java/com/spotify/github/v3/workflows/WorkflowsResponse.java
+++ b/src/main/java/com/spotify/github/v3/workflows/WorkflowsResponse.java
@@ -66,7 +66,7 @@ public interface WorkflowsResponse {
     /**
      * Deleted At
      *
-     * @return The time when the workflow was updated
+     * @return The time when the workflow was deleted
      */
     ZonedDateTime deletedAt();
 

--- a/src/main/java/com/spotify/github/v3/workflows/WorkflowsState.java
+++ b/src/main/java/com/spotify/github/v3/workflows/WorkflowsState.java
@@ -1,0 +1,30 @@
+/*-
+ * -\-\-
+ * github-api
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.github.v3.workflows;
+
+/** The Workflow State. */
+public enum WorkflowsState {
+  active,
+  deleted,
+  disabled_fork,
+  disabled_inactivity,
+  disabled_manually
+}

--- a/src/test/java/com/spotify/github/v3/clients/GitHubClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/GitHubClientTest.java
@@ -234,6 +234,35 @@ public class GitHubClientTest {
   }
 
   @Test
+  public void testGetWorkflow() throws Throwable {
+    final Call call = mock(Call.class);
+    final ArgumentCaptor<Callback> callbackCapture = ArgumentCaptor.forClass(Callback.class);
+    doNothing().when(call).enqueue(callbackCapture.capture());
+
+    final Response response = new okhttp3.Response.Builder()
+        .code(200)
+        .body(
+            ResponseBody.create(
+                MediaType.get("application/json"),
+                getFixture("../workflows/workflows-get-workflow-response.json")))
+        .message("")
+        .protocol(Protocol.HTTP_1_1)
+        .request(new Request.Builder().url("http://localhost/").build())
+        .build();
+
+    when(client.newCall(any())).thenReturn(call);
+    WorkflowsClient client = github.withTracer(tracer).createRepositoryClient("testorg", "testrepo")
+        .createActionsClient().createWorkflowsClient();
+
+    CompletableFuture<WorkflowsResponse> future = client.getWorkflow(161335);
+    callbackCapture.getValue().onResponse(call, response);
+    var result = future.get();
+
+    assertThat(result.id(), is(161335));
+    assertThat(result.state(), is(WorkflowsState.active));
+  }
+
+  @Test
   void asAppScopedClientGetsUserClientIfOrgClientNotFound() {
     var appGithub = GitHubClient.create(client, URI.create("http://bogus"), new byte[] {}, 1);
     var githubSpy = spy(appGithub);

--- a/src/test/java/com/spotify/github/v3/clients/GitHubClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/GitHubClientTest.java
@@ -40,6 +40,8 @@ import com.spotify.github.v3.exceptions.ReadOnlyRepositoryException;
 import com.spotify.github.v3.exceptions.RequestNotOkException;
 import com.spotify.github.v3.repos.CommitItem;
 import com.spotify.github.v3.repos.RepositoryInvitation;
+import com.spotify.github.v3.workflows.WorkflowsResponse;
+import com.spotify.github.v3.workflows.WorkflowsState;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/com/spotify/github/v3/clients/WorkflowsClientTest.java
+++ b/src/test/java/com/spotify/github/v3/clients/WorkflowsClientTest.java
@@ -1,0 +1,97 @@
+/*-
+ * -\-\-
+ * github-api
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.github.v3.clients;
+
+import com.google.common.io.Resources;
+import com.spotify.github.jackson.Json;
+import com.spotify.github.v3.workflows.WorkflowsRepositoryResponseList;
+import com.spotify.github.v3.workflows.WorkflowsResponse;
+import com.spotify.github.v3.workflows.WorkflowsState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.CompletableFuture;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class WorkflowsClientTest {
+
+  private static final String FIXTURES_PATH = "com/spotify/github/v3/workflows/";
+  private GitHubClient github;
+  private WorkflowsClient workflowsClient;
+  private Json json;
+
+  public static String loadResource(final String path) {
+    try {
+      return Resources.toString(Resources.getResource(path), UTF_8);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  @BeforeEach
+  public void setUp() {
+    github = mock(GitHubClient.class);
+    workflowsClient = new WorkflowsClient(github, "someowner", "somerepo");
+    json = Json.create();
+    when(github.json()).thenReturn(json);
+  }
+
+  @Test
+  public void getWorkflow() throws Exception {
+    final WorkflowsResponse workflowsResponse =
+        json.fromJson(
+            loadResource(FIXTURES_PATH + "workflows-get-workflow-response.json"), WorkflowsResponse.class);
+    final CompletableFuture<WorkflowsResponse> fixtureResponse = completedFuture(workflowsResponse);
+    when(github.request(any(), eq(WorkflowsResponse.class), any())).thenReturn(fixtureResponse);
+
+    final CompletableFuture<WorkflowsResponse> actualResponse =
+        workflowsClient.getWorkflow(161335);
+
+    assertThat(actualResponse.get().id(), is(161335));
+    assertThat(actualResponse.get().state(), is(WorkflowsState.active));
+  }
+
+  @Test
+  public void listWorkflows() throws Exception {
+    final WorkflowsRepositoryResponseList workflowsListResponse =
+        json.fromJson(
+            loadResource(FIXTURES_PATH + "workflows-list-workflows-response.json"), WorkflowsRepositoryResponseList.class);
+    final CompletableFuture<WorkflowsRepositoryResponseList> fixtureResponse = completedFuture(workflowsListResponse);
+    when(github.request(any(), eq(WorkflowsRepositoryResponseList.class), any())).thenReturn(fixtureResponse);
+
+    final CompletableFuture<WorkflowsRepositoryResponseList> actualResponse =
+        workflowsClient.listWorkflows();
+
+    assertThat(actualResponse.get().totalCount(), is(2));
+    assertThat(actualResponse.get().workflows().get(0).name(), is("CI"));
+    assertThat(actualResponse.get().workflows().get(1).name(), is("Linter"));
+  }
+}

--- a/src/test/resources/com/spotify/github/v3/workflows/workflows-get-workflow-response.json
+++ b/src/test/resources/com/spotify/github/v3/workflows/workflows-get-workflow-response.json
@@ -1,0 +1,13 @@
+{
+  "id": 161335,
+  "node_id": "MDg6V29ya2Zsb3cxNjEzMzU=",
+  "name": "CI",
+  "path": ".github/workflows/blank.yaml",
+  "state": "active",
+  "created_at": "2020-01-08T23:48:37.000-08:00",
+  "updated_at": "2020-01-08T23:50:21.000-08:00",
+  "deleted_at": "2020-01-09T23:50:21.000-08:00",
+  "url": "https://api.github.com/repos/octo-org/octo-repo/actions/workflows/161335",
+  "html_url": "https://github.com/octo-org/octo-repo/blob/master/.github/workflows/161335",
+  "badge_url": "https://github.com/octo-org/octo-repo/workflows/CI/badge.svg"
+}

--- a/src/test/resources/com/spotify/github/v3/workflows/workflows-list-workflows-response.json
+++ b/src/test/resources/com/spotify/github/v3/workflows/workflows-list-workflows-response.json
@@ -1,0 +1,31 @@
+{
+  "total_count": 2,
+  "workflows": [
+    {
+      "id": 161335,
+      "node_id": "MDg6V29ya2Zsb3cxNjEzMzU=",
+      "name": "CI",
+      "path": ".github/workflows/blank.yaml",
+      "state": "active",
+      "created_at": "2020-01-08T23:48:37.000-08:00",
+      "updated_at": "2020-01-08T23:50:21.000-08:00",
+      "deleted_at": "2020-01-09T23:50:21.000-08:00",
+      "url": "https://api.github.com/repos/octo-org/octo-repo/actions/workflows/161335",
+      "html_url": "https://github.com/octo-org/octo-repo/blob/master/.github/workflows/161335",
+      "badge_url": "https://github.com/octo-org/octo-repo/workflows/CI/badge.svg"
+    },
+    {
+      "id": 269289,
+      "node_id": "MDE4OldvcmtmbG93IFNlY29uZGFyeTI2OTI4OQ==",
+      "name": "Linter",
+      "path": ".github/workflows/linter.yaml",
+      "state": "active",
+      "created_at": "2020-01-08T23:48:37.000-08:00",
+      "updated_at": "2020-01-08T23:50:21.000-08:00",
+      "deleted_at": "2020-01-09T23:50:21.000-08:00",
+      "url": "https://api.github.com/repos/octo-org/octo-repo/actions/workflows/269289",
+      "html_url": "https://github.com/octo-org/octo-repo/blob/master/.github/workflows/269289",
+      "badge_url": "https://github.com/octo-org/octo-repo/workflows/Linter/badge.svg"
+    }
+  ]
+}


### PR DESCRIPTION
Hi @Abhi347!

Here is a small PR which adds get and list workflows from Github Actions API: 

 - List Workflows: https://docs.github.com/en/rest/actions/workflows#list-repository-workflows
 - Get Workflow: https://docs.github.com/en/rest/actions/workflows#get-a-workflow

Added tests as well for code coverage
