### PR TITLE
Make WorkflowsResponse.deletedAt field nullable

### DIFF
--- a/src/main/java/com/spotify/github/v3/workflows/WorkflowsResponse.java
+++ b/src/main/java/com/spotify/github/v3/workflows/WorkflowsResponse.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.spotify.github.GithubStyle;
 import org.immutables.value.Value;
 
+import javax.annotation.Nullable;
 import java.time.ZonedDateTime;
 
 @Value.Immutable
@@ -68,7 +69,7 @@ public interface WorkflowsResponse {
      *
      * @return The time when the workflow was deleted
      */
-    ZonedDateTime deletedAt();
+    @Nullable ZonedDateTime deletedAt();
 
     /**
      * Url string.


### PR DESCRIPTION
deletedAt field in WorkflowsResponse is not required according to the schema and therefore should be marked @Nullable.

Running without this fix causes an exception when deserialising the json response from GitHub with the root cause:

```
Cannot build WorkflowsResponse, some of required attributes are not set [deletedAt]
```