### PR TITLE
Fix deprecated annotation

### DIFF
--- a/src/main/java/com/spotify/github/v3/comment/Comment.java
+++ b/src/main/java/com/spotify/github/v3/comment/Comment.java
@@ -60,6 +60,7 @@ public interface Comment extends UpdateTracking {
    *
    * @deprecated Use {@link #position()} instead
    */
+  @Deprecated
   Optional<Integer> line();
 
   /** Relative path of the file to comment on. */


### PR DESCRIPTION
The  method in  was already marked as deprecated with a javadoc tag,
but it was missing the  annotation. This commit adds the missing annotation to
resolve a lint warning.