### PR TITLE
Fix nullable optionals

### DIFF
--- a/src/main/java/com/spotify/github/v3/activity/events/CreateEvent.java
+++ b/src/main/java/com/spotify/github/v3/activity/events/CreateEvent.java
@@ -47,7 +47,6 @@ public interface CreateEvent extends BaseEvent {
   String masterBranch();
 
   /** The repository's current description. */
-  @Nullable
   Optional<String> description();
 
   /** No doc found on github - Usually is "user". */

--- a/src/main/java/com/spotify/github/v3/activity/events/PushEvent.java
+++ b/src/main/java/com/spotify/github/v3/activity/events/PushEvent.java
@@ -93,7 +93,6 @@ public interface PushEvent {
   List<PushCommit> commits();
 
   /** The push commit object of the most recent commit on ref after the push. */
-  @Nullable
   Optional<PushCommit> headCommit();
 
   /** Pusher */

--- a/src/main/java/com/spotify/github/v3/activity/events/StatusEvent.java
+++ b/src/main/java/com/spotify/github/v3/activity/events/StatusEvent.java
@@ -66,7 +66,6 @@ public interface StatusEvent extends BaseEvent, UpdateTracking {
   String context();
 
   /** The optional human-readable description added to the status. */
-  @Nullable
   Optional<String> description();
 
   /** The new state. Can be pending, success, failure, or error. */

--- a/src/main/java/com/spotify/github/v3/issues/Issue.java
+++ b/src/main/java/com/spotify/github/v3/issues/Issue.java
@@ -48,11 +48,9 @@ public interface Issue extends CloseTracking {
   URI url();
 
   /** Events URL. */
-  @Nullable
   Optional<URI> eventsUrl();
 
   /** Repository URL. */
-  @Nullable
   Optional<URI> repositoryUrl();
 
   /** Labels URL template. */
@@ -80,7 +78,6 @@ public interface Issue extends CloseTracking {
   String title();
 
   /** The contents of the issue. */
-  @Nullable
   Optional<String> body();
 
   /** User. */

--- a/src/main/java/com/spotify/github/v3/prs/Review.java
+++ b/src/main/java/com/spotify/github/v3/prs/Review.java
@@ -51,7 +51,6 @@ public interface Review {
   User user();
 
   /** Body. */
-  @Nullable
   Optional<String> body();
 
   /** Submitted at. */

--- a/src/main/java/com/spotify/github/v3/repos/RepositoryInvitation.java
+++ b/src/main/java/com/spotify/github/v3/repos/RepositoryInvitation.java
@@ -61,7 +61,6 @@ public interface RepositoryInvitation {
   ZonedDateTime createdAt();
 
   /** Whether or not the invitation has expired */
-  @Nullable
   Optional<Boolean> expired();
 
   /** API URL */


### PR DESCRIPTION
This commit removes the @Nullable annotation from Optional attributes in several files.
This was causing lint warnings because the combination of @Nullable and Optional
is not recommended. The changes have been made in the following files:
- src/main/java/com/spotify/github/v3/activity/events/StatusEvent.java
- src/main/java/com/spotify/github/v3/issues/Issue.java
- src/main/java/com/spotify/github/v3/repos/RepositoryInvitation.java
- src/main/java/com/spotify/github/v3/prs/Review.java
- src/main/java/com/spotify/github/v3/activity/events/CreateEvent.java
- src/main/java/com/spotify/github/v3/activity/events/PushEvent.java
