### PR TITLE
Fix serializable warning

### DIFF
--- a/src/main/java/com/spotify/github/v3/exceptions/GithubException.java
+++ b/src/main/java/com/spotify/github/v3/exceptions/GithubException.java
@@ -22,6 +22,8 @@ package com.spotify.github.v3.exceptions;
 
 /** Common github exception */
 public class GithubException extends RuntimeException {
+  private static final long serialVersionUID = 1L;
+
 
   /**
    * C'tor for setting a message

--- a/src/main/java/com/spotify/github/v3/exceptions/ReadOnlyRepositoryException.java
+++ b/src/main/java/com/spotify/github/v3/exceptions/ReadOnlyRepositoryException.java
@@ -25,6 +25,8 @@ import java.util.Map;
 
 /** The Read only repository exception. */
 public class ReadOnlyRepositoryException extends RequestNotOkException {
+  private static final long serialVersionUID = 1L;
+
   /**
    * Instantiates a new Read only repository exception.
    *

--- a/src/main/java/com/spotify/github/v3/exceptions/RequestNotOkException.java
+++ b/src/main/java/com/spotify/github/v3/exceptions/RequestNotOkException.java
@@ -39,6 +39,8 @@ import java.util.Map;
 
 /** HTTP response with non-200 StatusCode. */
 public class RequestNotOkException extends GithubException {
+  private static final long serialVersionUID = 1L;
+
 
   private final int statusCode;
   private final String method;

--- a/src/main/java/com/spotify/github/v3/repos/Languages.java
+++ b/src/main/java/com/spotify/github/v3/repos/Languages.java
@@ -27,4 +27,6 @@ import java.util.LinkedHashMap;
  *
  * @see "https://developer.github.com/v3/repos/#list-languages"
  */
-public class Languages extends LinkedHashMap<String, Integer> {}
+public class Languages extends LinkedHashMap<String, Integer> {
+  private static final long serialVersionUID = 1L;
+}


### PR DESCRIPTION
Fix serializable class warnings.

This commit adds the missing `serialVersionUID` field to four Java classes that
were raising lint warnings about missing serialVersionUID. The added field
fixes the warnings.