### PR TITLE
Fix snake case

### DIFF
--- a/src/main/java/com/spotify/github/jackson/Json.java
+++ b/src/main/java/com/spotify/github/jackson/Json.java
@@ -20,7 +20,7 @@
 
 package com.spotify.github.jackson;
 
-import static com.fasterxml.jackson.databind.PropertyNamingStrategy.SNAKE_CASE;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import static java.util.Objects.isNull;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -248,6 +248,6 @@ public class Json {
             .enable(SerializationFeature.WRITE_DATES_WITH_ZONE_ID)
             .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
             .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-            .setPropertyNamingStrategy(SNAKE_CASE);
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
   }
 }


### PR DESCRIPTION
Fix deprecation warning by replacing SNAKE_CASE with PropertyNamingStrategies.SNAKE_CASE.

The PropertyNamingStrategy.SNAKE_CASE constant has been deprecated in favor of PropertyNamingStrategies.SNAKE_CASE.
This commit updates the code to use the current, non-deprecated naming strategy, resolving the lint warning.