### PR TITLE
fix: Fix the int vs long issue in IssueClient methods

### DIFF
--- a/src/main/java/com/spotify/github/v3/clients/IssueClient.java
+++ b/src/main/java/com/spotify/github/v3/clients/IssueClient.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 /** Issue API client */
 public class IssueClient {
 
+  // URI templates for various API endpoints
   static final String COMMENTS_URI_NUMBER_TEMPLATE = "/repos/%s/%s/issues/%s/comments";
   static final String COMMENTS_URI_TEMPLATE = "/repos/%s/%s/issues/comments";
   static final String COMMENTS_URI_ID_TEMPLATE = "/repos/%s/%s/issues/comments/%s";
@@ -50,106 +51,201 @@ public class IssueClient {
   private final String owner;
   private final String repo;
 
+  /**
+   * Constructs an IssueClient.
+   *
+   * @param github the GitHub client
+   * @param owner the repository owner
+   * @param repo the repository name
+   */
   IssueClient(final GitHubClient github, final String owner, final String repo) {
     this.github = github;
     this.owner = owner;
     this.repo = repo;
   }
 
+  /**
+   * Creates an IssueClient.
+   *
+   * @param github the GitHub client
+   * @param owner the repository owner
+   * @param repo the repository name
+   * @return a new IssueClient instance
+   */
   static IssueClient create(final GitHubClient github, final String owner, final String repo) {
     return new IssueClient(github, owner, repo);
   }
 
   /**
-   * List repository comments.
+   * Lists repository comments.
    *
-   * @return comments
+   * @return an iterator of asynchronous pages of comments
    */
   public Iterator<AsyncPage<Comment>> listComments() {
     return listComments(String.format(COMMENTS_URI_TEMPLATE, owner, repo));
   }
 
   /**
-   * List given issue number comments.
+   * Lists comments for a given issue number.
    *
-   * @param number issue number
-   * @return comments
+   * @param issueNumber the issue number
+   * @return an iterator of asynchronous pages of comments
    */
-  public Iterator<AsyncPage<Comment>> listComments(final int number) {
-    return listComments(String.format(COMMENTS_URI_NUMBER_TEMPLATE, owner, repo, number));
+  public Iterator<AsyncPage<Comment>> listComments(final long issueNumber) {
+    return listComments(String.format(COMMENTS_URI_NUMBER_TEMPLATE, owner, repo, issueNumber));
   }
 
   /**
-   * Get a specific comment.
+   * Lists comments for a given issue number.
    *
-   * @param id comment id
-   * @return a comment
+   * @deprecated Use {@link #listComments(long)} instead
+   * @param issueNumber the issue number
+   * @return an iterator of asynchronous pages of comments
    */
-  public CompletableFuture<Comment> getComment(final int id) {
-    final String path = String.format(COMMENTS_URI_ID_TEMPLATE, owner, repo, id);
+  @Deprecated
+  public Iterator<AsyncPage<Comment>> listComments(final int issueNumber) {
+    return listComments((long) issueNumber);
+  }
+
+  /**
+   * Gets a specific comment.
+   *
+   * @param commentId the comment id
+   * @return a CompletableFuture containing the comment
+   */
+  public CompletableFuture<Comment> getComment(final long commentId) {
+    final String path = String.format(COMMENTS_URI_ID_TEMPLATE, owner, repo, commentId);
     log.info("Fetching issue comments from " + path);
     return github.request(path, Comment.class);
   }
 
   /**
-   * Create a comment for a given issue number.
+   * Gets a specific comment.
    *
-   * @param number issue number
-   * @param body comment content
-   * @return the Comment that was just created
+   * @deprecated Use {@link #getComment(long)} instead
+   * @param commentId the comment id
+   * @return a CompletableFuture containing the comment
    */
-  public CompletableFuture<Comment> createComment(final int number, final String body) {
-    final String path = String.format(COMMENTS_URI_NUMBER_TEMPLATE, owner, repo, number);
+  @Deprecated
+  public CompletableFuture<Comment> getComment(final int commentId) {
+    return getComment((long) commentId);
+  }
+
+  /**
+   * Creates a comment for a given issue number.
+   *
+   * @param issueNumber the issue number
+   * @param body the comment content
+   * @return a CompletableFuture containing the created comment
+   */
+  public CompletableFuture<Comment> createComment(final long issueNumber, final String body) {
+    final String path = String.format(COMMENTS_URI_NUMBER_TEMPLATE, owner, repo, issueNumber);
     final String requestBody = github.json().toJsonUnchecked(ImmutableMap.of("body", body));
     return github.post(path, requestBody, Comment.class);
   }
 
   /**
-   * Edit a specific comment.
+   * Creates a comment for a given issue number.
    *
-   * @param id comment id
-   * @param body new comment content
+   * @deprecated Use {@link #createComment(long, String)} instead
+   * @param issueNumber the issue number
+   * @param body the comment content
+   * @return a CompletableFuture containing the created comment
    */
-  public CompletableFuture<Void> editComment(final int id, final String body) {
-    final String path = String.format(COMMENTS_URI_ID_TEMPLATE, owner, repo, id);
+  @Deprecated
+  public CompletableFuture<Comment> createComment(final int issueNumber, final String body) {
+    return createComment((long) issueNumber, body);
+  }
+
+  /**
+   * Edits a specific comment.
+   *
+   * @param commentId the comment id
+   * @param body the new comment content
+   * @return a CompletableFuture representing the completion of the operation
+   */
+  public CompletableFuture<Void> editComment(final long commentId, final String body) {
+    final String path = String.format(COMMENTS_URI_ID_TEMPLATE, owner, repo, commentId);
     return github
         .patch(path, github.json().toJsonUnchecked(ImmutableMap.of("body", body)))
         .thenAccept(IGNORE_RESPONSE_CONSUMER);
   }
 
   /**
-   * Delete a comment.
+   * Edits a specific comment.
    *
-   * @param id comment id
+   * @deprecated Use {@link #editComment(long, String)} instead
+   * @param commentId the comment id
+   * @param body the new comment content
+   * @return a CompletableFuture representing the completion of the operation
    */
-  public CompletableFuture<Void> deleteComment(final int id) {
+  @Deprecated
+  public CompletableFuture<Void> editComment(final int commentId, final String body) {
+    return editComment((long) commentId, body);
+  }
+
+  /**
+   * Deletes a comment.
+   *
+   * @param commentId the comment id
+   * @return a CompletableFuture representing the completion of the operation
+   */
+  public CompletableFuture<Void> deleteComment(final long commentId) {
     return github
-        .delete(String.format(COMMENTS_URI_ID_TEMPLATE, owner, repo, id))
+        .delete(String.format(COMMENTS_URI_ID_TEMPLATE, owner, repo, commentId))
         .thenAccept(IGNORE_RESPONSE_CONSUMER);
   }
 
+  /**
+   * Deletes a comment.
+   *
+   * @deprecated Use {@link #deleteComment(long)} instead
+   * @param commentId the comment id
+   * @return a CompletableFuture representing the completion of the operation
+   */
+  @Deprecated
+  public CompletableFuture<Void> deleteComment(final int commentId) {
+    return deleteComment((long) commentId);
+  }
+
+  /**
+   * Lists comments for a given path.
+   *
+   * @param path the API endpoint path
+   * @return an iterator of asynchronous pages of comments
+   */
   private Iterator<AsyncPage<Comment>> listComments(final String path) {
     return new GithubPageIterator<>(new GithubPage<>(github, path, LIST_COMMENT_TYPE_REFERENCE));
   }
 
   /**
-   * Get issue by id
+   * Gets an issue by id.
    *
-   * @param id issue id
-   * @return the Issue for the given id if exists.
+   * @param issueId the issue id
+   * @return a CompletableFuture containing the issue
    */
-  public CompletableFuture<Issue> getIssue(final int id) {
-    return github.request(String.format(ISSUES_URI_ID_TEMPLATE, owner, repo, id), Issue.class);
+  public CompletableFuture<Issue> getIssue(final long issueId) {
+    return github.request(String.format(ISSUES_URI_ID_TEMPLATE, owner, repo, issueId), Issue.class);
   }
 
   /**
-   * Create a reaction on a comment. See <a *
-   * href="https://docs.github.com/en/rest/reactions/reactions?apiVersion=2022-11-28#create-reaction-for-an-issue-comment">Create
-   * reaction for an issue comment</a>
+   * Gets an issue by id.
    *
-   * @param commentId comment id
-   * @param reaction reaction content
-   * @return the Comment that was just created
+   * @deprecated Use {@link #getIssue(long)} instead
+   * @param issueId the issue id
+   * @return a CompletableFuture containing the issue
+   */
+  @Deprecated
+  public CompletableFuture<Issue> getIssue(final int issueId) {
+    return getIssue((long) issueId);
+  }
+
+  /**
+   * Creates a reaction on a comment.
+   *
+   * @param commentId the comment id
+   * @param reaction the reaction content
+   * @return a CompletableFuture containing the created reaction
    */
   public CompletableFuture<CommentReaction> createCommentReaction(
       final long commentId, final CommentReactionContent reaction) {
@@ -160,12 +256,13 @@ public class IssueClient {
   }
 
   /**
-   * Delete a reaction on a comment. See <a
+   * Deletes a reaction on a comment. See <a
    * href="https://docs.github.com/en/rest/reactions/reactions?apiVersion=2022-11-28#delete-an-issue-comment-reaction">List
    * reactions for an issue comment</a>
    *
-   * @param issueNumber issue number
-   * @param reactionId reaction id
+   * @param issueNumber the issue number
+   * @param reactionId the reaction id
+   * @return a CompletableFuture containing the HTTP response
    */
   public CompletableFuture<HttpResponse> deleteCommentReaction(
       final long issueNumber, final long reactionId) {
@@ -175,12 +272,12 @@ public class IssueClient {
   }
 
   /**
-   * List reactions on a comment. See <a
+   * Lists reactions on a comment. See <a
    * href="https://docs.github.com/en/rest/reactions/reactions?apiVersion=2022-11-28#list-reactions-for-an-issue-comment">List
    * reactions for an issue comment</a>
    *
-   * @param commentId comment id
-   * @return reactions
+   * @param commentId the comment id
+   * @return an iterator of asynchronous pages of comment reactions
    */
   public GithubPageIterator<CommentReaction> listCommentReaction(final long commentId) {
     final String path = String.format(COMMENTS_REACTION_TEMPLATE, owner, repo, commentId);


### PR DESCRIPTION
Creates overloaded methods for both int and long ids in IssueClient and marks int ids as deprecated.