### PR TITLE
Documentation: Syntax error in Github.create #224

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To authenticate as a GitHub App, you must provide a private key and the App ID, 
 final GitHubClient githubClient =
   GitHubClient.create(
     URI.create("https://api.github.com/"),
-    new File("/path-to-the/private-key.pem"),
+    new File("/path-to-the/private-key.pem").toURI(),
     APP_ID);
 ```
 


### PR DESCRIPTION
While trying the api, I found the documentation to contain errors regarding the create method of the GithubClient. I hope this small edit would help others to avoid the similar problems 