### PR TITLE
feat: add `labels` to PullRequestItem

### DIFF
--- a/src/main/java/com/spotify/github/v3/prs/PullRequestItem.java
+++ b/src/main/java/com/spotify/github/v3/prs/PullRequestItem.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,6 +32,8 @@ import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
+
+import com.spotify.github.v3.issues.Label;
 import org.immutables.value.Value;
 
 /** Pull request item resource represents data returned during pull request list operation */
@@ -111,6 +113,10 @@ public interface PullRequestItem extends CloseTracking {
   /** User. */
   @Nullable
   User user();
+
+  /** A list of PR labels */
+  @Nullable
+  List<Label> labels();
 
   /** Statuses API URL. */
   @Nullable

--- a/src/test/java/com/spotify/github/v3/prs/PullRequestTest.java
+++ b/src/test/java/com/spotify/github/v3/prs/PullRequestTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.core.Is.is;
 import com.google.common.io.Resources;
 import com.spotify.github.jackson.Json;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -47,6 +48,8 @@ public class PullRequestTest {
     assertThat(pr.deletions(), is(3));
     assertThat(pr.changedFiles(), is(5));
     assertThat(pr.draft(), is(Optional.of(false)));
+    assertThat(Objects.requireNonNull(pr.labels()).size(), is(1));
+    assertThat(Objects.requireNonNull(pr.labels()).get(0).name(), is("bug"));
   }
 
   @Test

--- a/src/test/resources/com/spotify/github/v3/issues/issue.json
+++ b/src/test/resources/com/spotify/github/v3/issues/issue.json
@@ -31,9 +31,13 @@
   },
   "labels": [
     {
+      "id": 600797884,
+      "node_id": "MDU6TGFiZWw2MDA3OTc4ODQ=",
       "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
       "name": "bug",
-      "color": "f29513"
+      "color": "c5def5",
+      "default": true,
+      "description": null
     }
   ],
   "assignee": {

--- a/src/test/resources/com/spotify/github/v3/prs/pull_request.json
+++ b/src/test/resources/com/spotify/github/v3/prs/pull_request.json
@@ -351,9 +351,13 @@
   },
   "labels": [
     {
+      "id": 600797884,
+      "node_id": "MDU6TGFiZWw2MDA3OTc4ODQ=",
       "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
       "name": "bug",
-      "color": "f29513"
+      "color": "c5def5",
+      "default": true,
+      "description": null
     }
   ],
   "merge_commit_sha": "e5bd3914e2e596debea16f433f57875b5b90bcd6",

--- a/src/test/resources/com/spotify/github/v3/prs/pull_request.json
+++ b/src/test/resources/com/spotify/github/v3/prs/pull_request.json
@@ -349,6 +349,13 @@
     "type": "User",
     "site_admin": false
   },
+  "labels": [
+    {
+      "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
+      "name": "bug",
+      "color": "f29513"
+    }
+  ],
   "merge_commit_sha": "e5bd3914e2e596debea16f433f57875b5b90bcd6",
   "merged": false,
   "mergeable": true,

--- a/src/test/resources/com/spotify/github/v3/prs/pull_request_item.json
+++ b/src/test/resources/com/spotify/github/v3/prs/pull_request_item.json
@@ -345,5 +345,12 @@
     "received_events_url": "https://api.github.com/users/octocat/received_events",
     "type": "User",
     "site_admin": false
-  }
+  },
+  "labels": [
+    {
+      "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
+      "name": "bug",
+      "color": "f29513"
+    }
+  ]
 }

--- a/src/test/resources/com/spotify/github/v3/prs/pull_request_item.json
+++ b/src/test/resources/com/spotify/github/v3/prs/pull_request_item.json
@@ -348,9 +348,13 @@
   },
   "labels": [
     {
+      "id": 600797884,
+      "node_id": "MDU6TGFiZWw2MDA3OTc4ODQ=",
       "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
       "name": "bug",
-      "color": "f29513"
+      "color": "c5def5",
+      "default": true,
+      "description": null
     }
   ]
 }


### PR DESCRIPTION
This PR adds `labels` to the `PullRequestItem` object mapping.

Currently, the [Issues](https://github.com/spotify/github-java-client/blob/master/src/main/java/com/spotify/github/v3/issues/Issue.java) object already contains `labels`, which is a list of `Label` objects that the Issue has.

`PullRequest` behind the scenes are nearly identical to `Issue`, including having a list of labels. This PR copies the `labels` field from `Issues` into `PullRequestItem`

