### PR TITLE
fix: move `draft`, `automerge` & `labels` fields to PullRequestItem

### DIFF
--- a/src/main/java/com/spotify/github/v3/prs/PullRequest.java
+++ b/src/main/java/com/spotify/github/v3/prs/PullRequest.java
@@ -79,7 +79,4 @@ public interface PullRequest extends PullRequestItem {
   /** The mergeable state of this PR. */
   @Nullable
   String mergeableState();
-
-  @Nullable
-  AutoMerge autoMerge();
 }

--- a/src/main/java/com/spotify/github/v3/prs/PullRequestItem.java
+++ b/src/main/java/com/spotify/github/v3/prs/PullRequestItem.java
@@ -134,6 +134,10 @@ public interface PullRequestItem extends PartialPullRequestItem {
   @Nullable
   String nodeId();
 
+  /** Is Automerge Enabled */
+  @Nullable
+  AutoMerge autoMerge();
+
   /** Is it a draft PR? */
   Optional<Boolean> draft();
 


### PR DESCRIPTION
The fields `draft`, `automerge` & `labels` are now defined as part of the `PullRequest` object. However, `PullRequestItem` which is the object returned when listing PRs, also has them.

This PR moves the fields from `PullRequest` object to the `PullRequestItem` object. Filtering a list of PRs by labels is a common use case, and this fix would accommodate that.

Reference documentation: https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests