### PR TITLE
add 'previous_filename' field to FileItem for renamed files

### DIFF
--- a/src/main/java/com/spotify/github/v3/git/FileItem.java
+++ b/src/main/java/com/spotify/github/v3/git/FileItem.java
@@ -70,5 +70,9 @@ public interface FileItem {
   @Nullable
   String patch();
 
+  @Nullable
+  @JsonProperty("previous_filename")
+  String previousFilename();
+
 }
 


### PR DESCRIPTION
this optional field is present in the response schema for https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files and set when a file in the PR is renamed